### PR TITLE
asciidoc for mary ann kelty

### DIFF
--- a/lives-of-primitive-quakers/modernized/01-introduction.adoc
+++ b/lives-of-primitive-quakers/modernized/01-introduction.adoc
@@ -1,4 +1,4 @@
-== Introductory Chapter.
+== Introductory Chapter
 
 "`We walk by faith,`" says the apostle, "`and not by sight;`" (2 Cor. 5:7)
 Now, the obedience which results from the walk of faith,
@@ -259,8 +259,5 @@ known as the Christian's glorious dwelling-place;
 and let all his loving children say, "`This God is our God forever and ever,
 he will be our guide even unto death!`"
 
+[.signed-section-signature]
 M+++.+++ A. K.
-
-[.asterism]
-'''
-

--- a/lives-of-primitive-quakers/modernized/02-chapter-1.adoc
+++ b/lives-of-primitive-quakers/modernized/02-chapter-1.adoc
@@ -1,4 +1,4 @@
-== The Obedience of Faith.Chapter I.
+== Chapter I.
 
 In observing the dealings of Providence towards the human race,
 we generally discover that the most important consequences have resulted from what,
@@ -651,4 +651,3 @@ there was a secret unity in this little band of believers,
 which delivered them more than most other religious professors,
 from any fear or probability of being scattered, or brought to loss,
 under such a bereavement.
-

--- a/lives-of-primitive-quakers/modernized/03-chapter-2.adoc
+++ b/lives-of-primitive-quakers/modernized/03-chapter-2.adoc
@@ -292,7 +292,7 @@ and the next day, being a lecture, or a fast-day, he went to Ulverstone steeple-
 but came not in till the people were gathered.
 I and my children had been there a long time before.
 When they were singing before the sermon, he came in, and when they had done singing,
-he stood upon a seat or form,and desired that he might have liberty to speak,
+he stood upon a seat or form, and desired that he might have liberty to speak,
 and he that was in the pulpit said he might.^
 footnote:[If this intrusion on the part of George Fox,
 and this concession on the side of "`he that was in the pulpit,`" should,
@@ -728,4 +728,3 @@ when he meekly asks of his barbarous persecutors,
 for which of his good works were they about to stone him,
 "`for a good work we stone you not; but for blasphemy!`"^
 footnote:[John 10:33.]
-

--- a/lives-of-primitive-quakers/modernized/04-chapter-3.adoc
+++ b/lives-of-primitive-quakers/modernized/04-chapter-3.adoc
@@ -29,6 +29,10 @@ to address a letter to the judges and court in his behalf; and which,
 as manifesting the view that was taken of his case by a judicious and educated man,
 it may be desirable to give at length.
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`To the judges of court sessions and jail-delivery for the northern parts,
 sitting at Carlisle.
 
@@ -72,7 +76,10 @@ and has neither professed nor avowed them.^
 footnote:[G. Fox's Journal, folio edit.
 p. 101, 102.]
 
+[.signed-section-signature]
 "`Anthony Pearson.`"
+
+--
 
 But the friendly efforts of this gentleman were fruitless.
 It was resolved not to bring George Fox to trial; and he was left,
@@ -691,6 +698,10 @@ The result of these or other intercessions,
 occasioned an order to be sent down for their discharge;
 of which he gives the following copy:--
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Thursday, the 16th of October, at the Council at Whitehall.
 
 "`Ordered by his Highness the Lord Protector and the council,
@@ -702,7 +713,10 @@ or any of them (if any) may with most conveniency be taken off and discharged;
 and likewise to take order, that upon their being set at liberty, as aforesaid,
 they be forthwith sent to their respective homes.
 
+[.signed-section-signature]
 "`W. Jessop, clerk of the council.`"
+
+--
 
 Being thus aided,
 George Whitehead and his friends were not long before they received their freedom;
@@ -737,4 +751,3 @@ as he says had esteemed him either lost or dead;
 and finding the great hardships and persecutions he had undergone,
 they received him with great joy and kindness, and with less prejudice than heretofore,
 against the principles he had adopted, and the society to which he had united himself.
-

--- a/lives-of-primitive-quakers/modernized/05-chapter-4.adoc
+++ b/lives-of-primitive-quakers/modernized/05-chapter-4.adoc
@@ -96,7 +96,7 @@ But, besides that I may well hope to be forgiven for
 omitting to enter into so painful a detail,^
 footnote:[A minute account of the transactions alluded to,
 and of the severe trials of the primitive Quakers in general,
-may be found in Besse's Sufferings of Friends; the bare relation of which,
+may be found in [.book-title]#Besse's Sufferings of Friends#; the bare relation of which,
 occupies two closely printed folio volumes;
 and in which are records of cruelty on the one hand,
 and of Christian patience on the other, which, unless too well authenticated,
@@ -110,8 +110,13 @@ were the pleas made use of to trouble these unoffending people,
 if I present him with the following warrant, which, on one occasion,
 was issued against them by the magistrates.
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`City of Bristol.
 
+[.salutation]
 "`To the constables of the peace, of the ward of +++_______+++, and every of them.
 
 "`Forasmuch, as information has been given unto us upon oath,
@@ -132,10 +137,13 @@ or any of them, and all other suspected persons,
 and to apprehend or bring them before us, or some of us,
 to be dealt with according to law.
 
-"`Hereof fail not.
-Given the 25th of January, 1654.
+[.signed-section-closing]
+"`Hereof fail not. Given the 25th of January, 1654.
 
+[.signed-section-signature]
 "`Signed, John Gunning, Mayor, and eight others have added their signatures.`"
+
+--
 
 While at Bristol, on the occasion of the large meeting above mentioned,
 Edward Burrough was called to London,
@@ -251,7 +259,7 @@ and multitudes of the inhabitants of London wondering and gazing after an image 
 "`Edward Burrough caused to be printed;
 whereby he raised to himself a more lasting monument than by the
 erecting of a statue to his former friend Oliver Cromwell.`"^
-footnote:[Sewel's Histoiy, vol.
+footnote:[[.book-title]#Sewel's History#, vol.
 ii. p. 51. Lindfield edit.]
 
 Nor was it only with Oliver as the ruling authority,
@@ -359,7 +367,7 @@ and that we now suffer for your holy name, and for your honour and justice,
 and for your truth and holiness!
 O Lord, you know we are resolved to perish, rather than to lose one grain hereof!
 Amen, amen!`"^
-footnote:[Sewel's History, (Lindfield edition,) vol.ii.pp. 420, 425.]
+footnote:[[.book-title]#Sewel's History#, (Lindfield edition,) vol.ii.pp. 420, 425.]
 Much more is subjoined;
 but the foregoing extracts may suffice to show the
 simple integrity with which he pleaded the case;
@@ -536,4 +544,3 @@ No. And now you are freed from the temptations of him who has the power of death
 and are freed from your outward enemies,
 who hated you because of the life that dwelt in you, and remain at the right hand of God,
 where there is joy and pleasure forevermore!`"
-

--- a/lives-of-primitive-quakers/modernized/06-chapter-5.adoc
+++ b/lives-of-primitive-quakers/modernized/06-chapter-5.adoc
@@ -66,8 +66,7 @@ and the former proceedings against, him,
 and how unequal it was that they waived the other
 statutes lately made against nonconformists,
 and prosecuted him upon a statute formerly made against Catholic recusants +++[+++
-those who would not recongnize or submit to the Church of England]
-. He said,
+those who would not recognize or submit to the Church of England]. He said,
 that it was merely upon a spiritual and conscientious account that he could not swear,
 seeing it was against the command of Christ, and the apostles' doctrine.
 He said also, that he was able to make it appear,
@@ -189,8 +188,10 @@ rejoicing and praising God and the Lamb, that lives forever and forevermore.
 Amen! "`Your dear brother in the patience and sufferings of Christ,
 who abounds in perfect love to all the faithful flock of Christ everywhere.
 
+[.signed-section-signature]
 "`F. H.
 
+[.signed-section-context-close]
 "`From Appleby jail, the place of my rest, where my days and hours are pleasant unto me;
 the 4th of the 5th month, 1664.`"
 
@@ -378,4 +379,3 @@ let them know that I die in the faith which I lived in, and suffered for.`"
 After a few words of prayer to God, he spoke no more;
 but entered into his blissful and everlasting rest, in the fiftieth year of his age,
 having been a prisoner for the testimony of Jesus, nearly five years.
-

--- a/lives-of-primitive-quakers/modernized/07-chapter-6.adoc
+++ b/lives-of-primitive-quakers/modernized/07-chapter-6.adoc
@@ -691,6 +691,7 @@ who has thus far set me free to praise his righteousness and his mercy!
 And to the eternal, invisible, pure God, over all, be fear, obedience, and glory,
 forevermore!-- Amen!
 
+[.signed-section-signature]
 "`James Nayler.`"
 
 In another paper, wherein he relates more circumstantially,
@@ -884,4 +885,3 @@ who through death obtained this resurrection, and eternal, holy life!`"
 Such was the end of James Nayler; who, in his forty-fourth year, "`chastened,
 but not killed-- cast down, but not destroyed`"--through much tribulation, entered,
 we may humbly hope, into the kingdom of God.
-

--- a/lives-of-primitive-quakers/modernized/08-chapter-7.adoc
+++ b/lives-of-primitive-quakers/modernized/08-chapter-7.adoc
@@ -292,7 +292,10 @@ is accounted for; while upon any other ground it is unaccountable.
 
 And as, according to the poet's statement respecting ambition:
 
+[verse]
+____
 "`It often over-leaps itself, and falls on the other side.`"
+____
 
 So, it commonly happens with sinister designs for individual security.
 This excessive determination, on the part of the inhabitants of Boston,
@@ -777,6 +780,10 @@ being an inhabitant of New England, had been banished on pain of death,
 if ever he returned there.
 To him the king granted a deputation, with full power to carry the following mandamus:--
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Charles R.
 
 "`Trusty and well beloved, we greet you well.
@@ -795,19 +802,19 @@ to the end that such course may be taken with them here,
 as shall be agreeable to our laws, and their demerits.
 And for so doing, these our letters shall be your sufficient warrant and discharge.
 
-"`Given at our court at Whitehall, the 9th day of September, 1661,
-in the thirteenth year of our reign.
+[.signed-section-closing]
+"`Given at our court at Whitehall, the 9th day of September, 1661, in the thirteenth year of our reign.
 
+[.signed-section-closing]
 "`By his Majesty's command,
 
+[.signed-section-signature]
 "`William Morris.
 
-Addressed: "`To our trusty and well-beloved John Endicot, Esq.,
-and to all and every other the governor, or governors of our plantations of New England,
-and of all the colonies thereunto belonging, that now are, or hereafter shall be;
-and to all and every the ministers and officers
-of our said plantations and colonies whatsoever,
-within the continent of New England.`"
+[.postscript]
+"`Addressed: To our trusty and well-beloved John Endicot, Esq., and to all and every other the governor, or governors of our plantations of New England, and of all the colonies thereunto belonging, that now are, or hereafter shall be; and to all and every the ministers and officers of our said plantations and colonies whatsoever, within the continent of New England.`"
+
+--
 
 This mandamus being obtained, no time was lost in dispatching it; and in six weeks' time,
 Samuel Shattock, the bearer of it, entered the Bay of Boston, on a Sunday morning.
@@ -843,4 +850,3 @@ he returned to the two friends, and said, "`We shall obey his majesty's command.
 The master of the ship afterwards giving liberty to the passengers to come ashore,
 they met together with their friends of the town, and offered up praises to God,
 for this wonderful deliverance.
-

--- a/lives-of-primitive-quakers/modernized/09-chapter-8.adoc
+++ b/lives-of-primitive-quakers/modernized/09-chapter-8.adoc
@@ -403,4 +403,3 @@ in drawing to the conclusion of his address to them, "`consider your cause again
 in a more meek and upright spirit; and you yourselves will easily see, how in your heart,
 you have been mistaken, and dealt more injuriously with others,
 than you yourselves were ever dealt with.`"
-

--- a/lives-of-primitive-quakers/modernized/10-chapter-9.adoc
+++ b/lives-of-primitive-quakers/modernized/10-chapter-9.adoc
@@ -128,7 +128,7 @@ and the jailer being at the door, "`I gave him something,`" he says,
 and he let me pass out without interruption.
 But soon after, Isaac Penington coming to visit them, he stopped him,
 and caused him to be made a prisoner.^
-footnote:[G. Fox's Journal, p. 419.]
+footnote:[[.book-title]#G. Fox's Journal#, p. 419.]
 
 One of the most unrelenting foes of this excellent man, was the Earl of Bridgewater,
 who upon some account or another,
@@ -137,8 +137,13 @@ more than once, was the cause of his imprisonment.
 It was during one of these occasions, that he addressed a letter to him,
 from which a few extracts are here made.
 
-"`To The Earl of Bridgewater.
+[.embedded-content-document.letter]
+--
 
+[.letter-heading]
+To The Earl of Bridgewater.
+
+[.salutation]
 "`Friend,
 
 "`It is the desire of my heart to walk with God, in the true fear of his name,
@@ -169,6 +174,8 @@ These things very nearly concern you.
 Oh, wait upon God for his true light, that you may not be deceived about them;
 because your loss thereby will be so great and irreparable.`"
 
+--
+
 But however painful to the nature of the "`outward man`" these sufferings might be,
 the "`hidden man of the heart`" was thereby perfected, in no ordinary degree,
 in the case of Isaac Penington.
@@ -176,15 +183,15 @@ Most of his inestimable letters, as well as the above,
 were written within the walls of a prison; and of the preciousness of these testimonies,
 many, then unborn, have tasted with profit and delight.
 
-Yes, good and faithful servant!--well-instructed
-scribe!--bringing forth out of your treasures,
+Yes, good and faithful servant! --well-instructed
+scribe!-- bringing forth out of your treasures,
 things new and old--you have fed many!
 Be your just memory blessed! and let a heart that owes you much, thus,
 in most true and tender love, record its gratitude.
 
 Of his deportment in the tribulations that befel him,
 there are many pleasing testimonies; but I select one only from the pen of Robert Jones,^
-footnote:[Prefixed to the Works of Penington.]
+footnote:[Prefixed to the [.book-title]#Works of Penington#.]
 his friend, and often, fellow-prisoner.
 
 "`What shall I say?`"
@@ -211,6 +218,10 @@ whose faithfulness rendered them worthy of it.
 The following letter from him to George Fox,
 exemplifies this amiable disposition very pleasingly:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear G. F.
 
 "`I feel the tender mercy of the Lord, and some portion of that brokenness, fear,
@@ -230,14 +241,19 @@ and may walk in perfect humility and tenderness of spirit before him, all my day
 Be helpful to me in tender love, that I may feel settlement and stability in the truth;
 and perfect separation from, and dominion in the Lord, over all that is contrary thereto.
 
+[.signed-section-signature]
 "`I. P.
 
-"`Aylesbury Jail, "`15th Fifth month, 1667.
+[.signed-section-context-close]
+"`Aylesbury Jail, 15th Fifth month, 1667.`"
 
+[.postscript]
 "`I entreat your prayers for my family, that the name of the Lord may be exalted,
 and his truth flourish therein.
 Dear G. F., indeed my soul longs for the pure, full,
 and undisturbed reign of the Life in me.`"
+
+--
 
 Being well fitted and prepared by sanctified suffering, he was ready for death; and,
 as William Penn describes him, under that exigency, "`had nothing else to do but to die,
@@ -373,7 +389,7 @@ when at any time I looked on the man, I was hardly able to forbear disdaining th
 but on the other hand,
 when the eye of my spirit beheld the power and glory of the Lord in them,
 I could hardly forbear over-esteeming, and exalting them.`"^
-footnote:[Penington's Works, vol.
+footnote:[[.book-title]#Penington's Works,# vol.
 i. p. 632.]
 
 But is not this the way of the Lord,--the invariable way?--we would ask.
@@ -600,5 +616,5 @@ After a few more words, she concludes by saying,
 "`this testimony to dear Isaac Penington,
 is from the greatest loser of all that had a share in his life,
 
+[.signed-section-signature]
 "`Mary Penington.`"
-

--- a/lives-of-primitive-quakers/modernized/11-chapter-10.adoc
+++ b/lives-of-primitive-quakers/modernized/11-chapter-10.adoc
@@ -283,72 +283,51 @@ upon the whole, was their portion in this dark and cloudy day,
 by offering to the reader a few stanzas of Catherine's humble, but very sweet poetry,
 looking at it in spirit.
 
+[verse]
+____
 HYMN TO GOD.^
 footnote:[Only a selection is given from this poem.]
 
 All praise to him that has not put,
-
 Nor cast me out of mind;
-
 Nor yet his mercy from me shut,
-
 As I could ever find.
 
 Oh none is like unto the Lamb,
-
 "`Whose beauty shineth bright!
-
 O! glorify his holy name,
-
 His majesty and might.
 
 My soul, praise thou the only God,
-
- A fountain pure and clear;
-
+A fountain pure and clear;
 Whose crystal streams spread all abroad,
-
 And cleanseth far and near.
 
 My sweet, and dear beloved one,
-
 Whose voice is more to me
-
 Than all the glory of the earth,
-
 Or treasures I can see.
 
 My soul, praise thou the Lord I say,
-
 Praise him with joy and peace;
-
 My spirit and mind, both night and day,
-
 Praise him and never cease.
 
 Oh, praises, praises, to our God!
-
 Sing praises to our King;
-
 O teach the people, all abroad,
-
 His praises for to sing.
 
 A Zion song of glory bright,
-
 That does shine out so clear;
-
 O manifest it in the sight
-
 Of nations far and near.
 
 That God may have his glory due,
-
 His honour and his fame;
-
 And all his saints may sing anew
-
 The praises of his name.
+____
 
 It is worthy of observation, and certainly tending to spiritual progress,
 to consider how much the soul thrives in the exercise of praise.
@@ -377,7 +356,7 @@ and brother,`"--telling him that she has unity and fellowship with him day and n
 "`Oh my dear husband and children,`" she says,
 "`how often have I poured out my soul to the everlasting Father for you,
 with rivers of tears night and day,
-that you might be kept pure and single in the sight of our God . . .
+that you might be kept pure and single in the sight of our God. . .
 
 "`My dear hearts, you do not lack teaching; you are in a land of blessedness,
 which flows with milk and honey! among the faithful
@@ -397,8 +376,7 @@ The Lord has exercised my patience, and tried me to the uttermost; to his praise
 and my eternal comfort, who has not failed us in anything,
 but has given abundantly in his own due time.
 We are witnesses that he can provide a table in the wilderness,
-both spiritual and temporal.
-. . .
+both spiritual and temporal. . .
 
 "`In our deepest affliction, when I looked for every breath to be the last,
 I could not wish I had not come over the sea;
@@ -562,4 +540,3 @@ all that I desire of you is, that when you pray to God,
 you will remember me in your prayers.'
 
 "`And so they parted.`"
-

--- a/lives-of-primitive-quakers/modernized/12-chapter-11.adoc
+++ b/lives-of-primitive-quakers/modernized/12-chapter-11.adoc
@@ -18,8 +18,13 @@ to exhort him to exercise mercy and forgiveness towards his enemies,
 and to warn him to restrain the profaneness and
 looseness that was got up in the nation on his return.`"
 
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
 To The King.
 
+[.salutation]
 "`King Charles,
 
 "`You entered not into this nation by sword, nor by victory of war,
@@ -48,7 +53,10 @@ in which we have peace, and that we may not be brought into ungodliness by them.
 Hear, and consider, and do good in your time, while you have power.
 Be merciful and forgive; that is the way to overcome, and obtain the kingdom of Christ.
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 At the time of writing this epistle, George was a prisoner in Lancaster Castle;
 where he had been roughly taken, while visiting his friend Margaret Fell at Swarthmore,
@@ -64,6 +72,9 @@ with the addition of his holding fanatic
 opinions,) he answered it by a sort of manifesto,
 which is far too lengthy for insertion as it stands;
 but from which a few extracts may be acceptable.
+
+[.embedded-content-document.letter]
+--
 
 "`I am a prisoner at Lancaster, committed by Justice Porter.
 A copy of the court order I cannot get; but such expressions I am told are in it,
@@ -94,11 +105,16 @@ but all are of a mad, foolish, furious spirit, that wrestle with flesh and blood
 and with carnal weapons, in their furiousness, foolishness and rage.
 This is not the Spirit of God, but of error, that persecutes in a mad, blind zeal,
 like Nebuchadnezzar and Saul.`"
+
 He subscribes this paper,
 
+[.signed-section-closing]
 "`From an innocent sufferer in bonds, and close prisoner in Lancaster Castle; called
 
+[.signed-section-signature]
 "`George Fox.`"
+
+--
 
 In the meantime many exertions were making on the part of his friends,
 towards his emancipation; Margaret Fell going herself to London,
@@ -221,38 +237,42 @@ many friends being in prison,
 because they could not burden their consciences
 by taking the oath of allegiance and supremacy.
 
-"`King.
-But why cannot you swear?
+[.discourse-part]
+"`__King__--But why cannot you swear?
 for an oath is a common thing amongst men to any engagement?
 
-"`R. H. Yes: it is manifest, and we have seen by experience,
+[.discourse-part]
+"`__R. H.__--Yes: it is manifest, and we have seen by experience,
 that it is so common amongst men to swear, and engage either for, or against things,
 that there is no regard taken to it, nor fear of an oath.
 That therefore, which we speak of, in the truth of our hearts,
 is more than what they can swear.
 
-"`King.
-But can you promise before the Lord?
+[.discourse-part]
+"`__King__--But can you promise before the Lord?
 which is the substance of an oath.
 
-"`R. H. Yes; what we do affirm, we can promise before the Lord,
+[.discourse-part]
+"`__R. H.__--Yes; what we do affirm, we can promise before the Lord,
 and take him to our witness in it.
 But our so promising has not been accepted;
 but the ceremony of an oath they have stood for; without which,
 all other things were accounted of no effect.
 
-"`King.
-But how may we know from your words, that you will perform?
+[.discourse-part]
+"`__King__--But how may we know from your words, that you will perform?
 
-"`R. H. By proving us: for they that swear, are not known to be faithful,
+[.discourse-part]
+"`__R. H.__--By proving us: for they that swear, are not known to be faithful,
 but by proving them; and so we, by those that have tried us,
 are found to be truer in our promises, than others by their oaths;
 and to those that do yet prove us, we shall appear the same.
 
-"`King.
-Pray what is your principle?
+[.discourse-part]
+"`__King__--Pray what is your principle?
 
-"`R. H. Our principle is this;
+[.discourse-part]
+"`__R. H.__--Our principle is this;
 that Jesus Christ is 'the true light that enlightens every one that
 comes into the world,' that all men through him might believe;
 and that they are to obey and follow this light, as they have received it;
@@ -263,14 +283,16 @@ Some further discourse ensued upon the subject of the sacrament,
 in which the lords in waiting also joined; after which, the king asked him,
 "`How know you that you are inspired by the Lord?`"
 
-"`R. H. According as we read in the scriptures,
+[.discourse-part]
+"`__R. H.__--According as we read in the scriptures,
 that 'the inspiration of the Almighty gives understanding,' so, by his inspiration,
 is an understanding given us of the things of God.'
 
 One of the lords in waiting then inquired,`" How
 do you know that you are led by the true spirit?`
 
-"`R. H. This we know, because the Spirit of truth reproves the world of sin; and by it,
+[.discourse-part]
+"`__R. H.__--This we know, because the Spirit of truth reproves the world of sin; and by it,
 we are reproved of sin, and are also led from sin unto righteousness,
 and obedience of truth; by which effects, we know it is the true Spirit;
 for the spirit of the wicked one does not lead into such things.`"
@@ -340,4 +362,3 @@ notwithstanding all the depredations they had
 suffered at the hands of these their enemies,
 friends could praise God, "`that they had a kettle, a platter, a horse,
 and a plough still.`"
-

--- a/lives-of-primitive-quakers/modernized/13-chapter-12.adoc
+++ b/lives-of-primitive-quakers/modernized/13-chapter-12.adoc
@@ -166,13 +166,17 @@ to ratify and confirm truth between them.`"
 Thirdly: in what case was an oath to be used?
 He specifies four occasions in which it was chiefly required.
 
+[.numbered]
 I+++.+++ In case of a promise or vow to God.
 
+[.numbered]
 II. In case of promise to man.
 
+[.numbered]
 III.
 In case of pronouncing or declaring the truth of a thing, etc.
 
+[.numbered]
 IV. In case of controversy between parties, where it could not be determined,
 but by taking the confession of one party for truth.
 
@@ -182,13 +186,17 @@ comprise the substance of the rest.
 He then speaks of four states or conditions of the soul, since the creation,
 preparatory to his applying the matter to the case of friends.
 
+[.numbered]
 1+++.+++ A state of integrity, wherein man could not lie nor deceive.
 
+[.numbered]
 2+++.+++ A state of deep captivity to evil, etc.
 
+[.numbered]
 3+++.+++ A state of shadowy redemption from evil, etc.,
 wherein were figures of heavenly things--but not the very things themselves.
 
+[.numbered]
 4+++.+++ A state of true redemption, which state, he thanks God,
 is (after a long night of apostasy) again brought forth.
 
@@ -258,6 +266,10 @@ with most others of the Society, was often made the subject of suffering.
 I allude to the question about the payment of tithes;
 upon which he thus expresses himself in a letter addressed to one James Eeles;
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Friend,
 
 "`God is my witness, to whom I must give an account of all my actions,
@@ -276,7 +288,12 @@ what God's power has disannulled,--indeed I do not see;
 nor can I be subject to any human law or authority in this thing,
 without sinning against God, and incurring his wrath upon my soul.
 
+--
+
 He then observes, that Christ sent forth his ministers without tithes.
+
+[.embedded-content-document.letter]
+--
 
 "`Now tithes,`" he continues, "`were set up in the dark times of Roman Catholicism,
 and not by the gospel light; and they who know the gospel light,
@@ -291,9 +308,10 @@ both which ministry and its maintenance, is to be denied and witnessed against,
 by those whom he calls forth to testify to his truth in these things.`"^
 footnote:[Penington's Letters, p. 157.]
 
+--
+
 Such being the views of Isaac Penington, and of the members of the Society in general,
 upon these questions, it appears a necessary consequence,
 that they should resolutely maintain the ground they had taken,
 and willingly devote themselves to persecution, even had it been to death,
 rather than violate such truly pure and exalted principles.
-

--- a/lives-of-primitive-quakers/modernized/14-chapter-13.adoc
+++ b/lives-of-primitive-quakers/modernized/14-chapter-13.adoc
@@ -124,8 +124,7 @@ on the part of government, accompanied every fresh plot.
 
 Amongst those who were at this time in prison, Margaret Fell was one;
 of whose examination at Lancaster court sessions, there is an account preserved,^
-footnote:[In a "`Brief Collection of Remarkable Passages,
-etc relating to Margaret Fell,`" p. 276.]
+footnote:[In a [.book-title]#"`Brief Collection of Remarkable Passages, etc relating to Margaret Fell,`"# p. 276.]
 which, taken in conjunction with that of George Fox,
 respecting his trial at the same place, and time, and on the same occasion,
 affords a curious specimen of the calm, and somewhat amusing inflexibility,
@@ -184,12 +183,14 @@ but for keeping of unlawful meetings: you think that if you do not fight, and qu
 or break the peace, that you break no law:
 but there is a law against unlawful meetings.`"
 
-M+++.+++ F. "`What law have I broken for worshipping God in my own house?`"
+[.discourse-part]
+__M+++.+++ F.__--"`What law have I broken for worshipping God in my own house?`"
 
-Judge.
-"`The common law.`"
+[.discourse-part]
+__Judge__--"`The common law.`"
 
-M+++.+++ F. "`I thought you had proceeded by a statute.`"
+[.discourse-part]
+__M+++.+++ F.__--"`I thought you had proceeded by a statute.`"
 Here the judge probably floundering a little,
 one of the sheriffs whispered him of a statute, 35th Elizabeth!`"
 
@@ -200,10 +201,11 @@ upon the account of her adhering to the dictates of her conscience,
 he must do as he would.
 She then desired to speak to the jury.
 
-Judge.
-"`The jury is to hear nothing but me tender you the oath; and you refuse, or take it.`"
+[.discourse-part]
+__Judge__--"`The jury is to hear nothing but me tender you the oath; and you refuse, or take it.`"
 
-M+++.+++ F. "`You will let me have the liberty that other prisoners have;`" which having said,
+[.discourse-part]
+__M+++.+++ F.__--"`You will let me have the liberty that other prisoners have;`" which having said,
 she turned to the jury, and once more related the cause of her imprisonment,
 and her reasons for not swearing.
 "`I am here,`" she said, "`this day, upon the account of my conscience,
@@ -220,16 +222,17 @@ But Margaret pursuing her point, still continued speaking,
 regardless of his repeated queries, "`Will you take the oath or no?`"
 till, in much wrath, he commanded that the book should again be tendered her.
 
-Judge.
-"`Will you take the oath of allegiance, yes, or no?`"
+[.discourse-part]
+__Judge__--"`Will you take the oath of allegiance, yes, or no?`"
 
-M+++.+++ F. "`I have said already, I acknowledge allegiance and obedience to the king,
+[.discourse-part]
+__M+++.+++ F.__--"`I have said already, I acknowledge allegiance and obedience to the king,
 and his just and lawful commands;
 and I do also own allegiance and obedience unto Christ Jesus, who is the King of kings,
 who has commanded me not to swear at all.`"
 
-Judge.
-"`That is no answer.
+[.discourse-part]
+__Judge__--"`That is no answer.
 Will you take the oath, or not take it?`"
 A question which only brought the same reply, that she owed allegiance to Christ,
 who forbade her swearing.
@@ -496,4 +499,3 @@ and the bad usage I had received in prison;
 and also that I was informed that no man could deliver me but he;`" which statement,
 in connection with the representations of some of his friends,
 at length succeeded in procuring an order for his release.
-

--- a/lives-of-primitive-quakers/modernized/15-chapter-14.adoc
+++ b/lives-of-primitive-quakers/modernized/15-chapter-14.adoc
@@ -154,17 +154,21 @@ And to show that there remained a sincerity in the man,
 after his mind came to be settled, he wrote a letter to some friends in London,
 wherein he has these words following:--
 
-"`'I dare not much stir up or down any way, for people's looking at what was done;
-lest the Lord should be offended, etc.
+[.embedded-content-document.letter]
+--
 
-"`'I have been much tempted and exercised; yet, through mercy,
+"`'I dare not much stir up or down any way, for people's looking at what was done;
+lest the Lord should be offended, etc. I have been much tempted and exercised; yet, through mercy,
 have found help in the needful time.
 Whatsoever slips or failings friends saw in me, in the time I was with them,
 I would have none take notice of; for I was under great exercises,
 and often ran too fast, which the Lord in his due time, gave me a sight of.
 In the love of my Father, farewell!
 
+[.signed-section-signature]
 "`'T. I. '`"
+
+--
 
 Nor was it only to this person,
 that a foreshadowing was vouchsafed of this fearful calamity: George Fox, in his Journal,
@@ -221,4 +225,3 @@ where taking leave of each other in the Lord, we parted;
 betaking ourselves each to our several services;
 Margaret returning homewards to the north,
 and I passing on in the work of the Lord as before.`"
-

--- a/lives-of-primitive-quakers/modernized/16-chapter-15.adoc
+++ b/lives-of-primitive-quakers/modernized/16-chapter-15.adoc
@@ -26,7 +26,7 @@ ever afterwards engaged in military concerns.
 
 Being now, by the situation of public affairs,
 incapable of rendering any further service to his prince, he retired to Gordonstoun;
-between which place, and Edinburgh, he chiefly passed his time, until the year 1C63;
+between which place, and Edinburgh, he chiefly passed his time, until the year 1663;
 at which period he experienced the trial of losing his excellent wife.^
 footnote:[He had married Catherine Gordon, eldest daughter of Sir Robert Gordon,
 of Gordonstoun, second son to the Earl of Sutherland.]
@@ -215,7 +215,7 @@ I felt a secret power among them, which touched my heart; and as I gave way unto
 I found the evil weakening in me, and the good raised up;
 and so I became thus knit and united unto them,
 hungering more and more after the increase of this power and life,
-whereby I might feel myself perfectly redeemed!`" -- (Barclay's Works, vol.
+whereby I might feel myself perfectly redeemed!`" -- ([.book-title]#Barclay's Works#, vol.
 ii. p. 353--356.)
 
 It is not easily believed,
@@ -253,8 +253,7 @@ resist the insinuations that were used to proselyte me to that way,
 I became quickly defiled with the pollutions thereof; until it pleased God,
 in his rich love and mercy, to deliver me out of those snares,
 and to give me a clear understanding of the evil of that way.`"^
-footnote:["`Treatise on Universal Love.`"--Barclay's Works, vol.
-iii. p. 186.]
+footnote:[Treatise on Universal Love, from [.book-title]#Barclay's Works#, vol. iii. p. 186.]
 
 About the year 1670, Robert Barclay married Christian Molleson,
 a very estimable young woman, united in profession with friends.
@@ -275,7 +274,7 @@ that I can say in the fear of the Lord,
 that I have received a charge from him to love you,
 and for that I know his love is much towards you, and his blessing and goodness is,
 and shall be unto you, so long as you abide in a true sense of it.`"^
-footnote:[The Friends in Scotland, by John Barclay, p. 295.]
+footnote:[[.book-title]#The Friends in Scotland#, by John Barclay, p. 295.]
 
 It was the lot of Robert Barclay, in common with many others amongst friends,
 to feel himself commanded by the Divine will,
@@ -345,6 +344,10 @@ that it was by no concessions inimical to truth on their side, we have ample tes
 in a noble appeal made in their joint names, to the magistrates who had committed them,
 and which begins thus:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Friends,
 
 "`Our case being as it was, and as some of us fully represented it to you,
@@ -362,7 +365,12 @@ your iniquities in this and the like cases,
 and you cannot vanquish us.
 You imagine a vain thing, and you will herein weary yourselves with very vanity.`"
 
+--
+
 After some close expostulations, it thus concludes:--
+
+[.embedded-content-document.letter]
+--
 
 "`Well! we ask nothing of you, but that you come to a sense of your past way,
 that you may not fall into the like for the future.
@@ -375,9 +383,12 @@ We are, as regards our testimony, and for its sake, well contented, well pleased
 well satisfied to be here; our bonds are not grievous unto us,
 glory to the Lord forever! who has not been, and who is not far from us.
 
+[.signed-section-signature]
 "`John Swintoune, William Napiek, John Milne, Robert Barclay, James Nuccoll,
 William Low.`"^
-footnote:[Barclay's Friends in Scotland, p. 315-- 316.]
+footnote:[[.book-title]#Barclay's Friends in Scotland#, p. 315-- 316.]
+
+--
 
 While the younger Barclay was thus valiantly contending for the truth,
 and also suffering in its behalf, David Barclay, the father,
@@ -414,8 +425,13 @@ by the tenor of which epistle,
 she seems to have received information of somewhat an exaggerated kind,
 respecting his case.
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Herford, December 19th, 1676.
 
+[.salutation]
 "`Dear Brother,
 
 "`I have written to you some months ago, by Robert Barclay, who passed this way,
@@ -434,7 +450,7 @@ etc.--'I should admire,`" she says,
 in a former letter to R. B.--"`I should admire God's providence,
 if my brother could be a means of releasing your father and forty more in Scotland:
 having promised to do his best,
-I know he will perform it.`"-- Barclay's Friends in Scotland, p. 354.]
+I know he will perform it.`" From [.book-title]#Barclay's Friends in Scotland#, p. 354.]
 to the council of Scotland,
 he has been clapped up in prison with the rest of his friends,
 and they threaten to hang him (at least those they call preachers
@@ -450,7 +466,10 @@ than in a sensible compassion of the innocent sufferers.
 You will act herein according to your own discretion:
 and I beseech you still consider me as yours,
 
+[.signed-section-signature]
 "`Elizabeth.`"
+
+--
 
 It does not appear that the above application was speedily, if at all, influential,
 in the liberation of Robert Barclay; who, with his friends,
@@ -487,6 +506,9 @@ After reminding them of the "`blessed visitation`" and
 tender mercy of the Lord towards them as a people,
 he says,
 
+[.embedded-content-document.letter]
+--
+
 "`Indeed the Lord is with us--what can we desire more?
 preparing us for himself, preserving us in the life of his blessed truth,
 building us up more and more,
@@ -516,9 +538,13 @@ whose breathings are to God for you, and his praises unto him,
 through the sense of his being with you, and daily showing mercy to you,
 upholding and preserving you in the midst of your sore trials and afflictions.
 
+[.signed-section-signature]
 "`Isaac Penington.`"
 
+[.signed-section-context-close]
 "`London, 5th of 5th month, 1676.`"
+
+--
 
 One of the pretences made use of by the authorities of Scotland,
 for their cruel proceedings against the Quakers,
@@ -539,7 +565,7 @@ the magistrates assembled a large concourse of the citizens, and with much parad
 went forth to meet them, expressing all the usual tokens of profound respect;
 so that on that occasion,
 "`the whole town appeared in a manner taken up with the grandeur of the ceremony.`"^
-footnote:[ J. Barclay's Friends in Scotland, p. 385.]
+footnote:[[.book-title]#J. Barclay's Friends in Scotland#, p. 385.]
 
 On reading which,
 the mind involuntarily recurs to the homely proverb of "`one may steal a horse,
@@ -741,4 +767,3 @@ he now wished on that day, to bear witness in their favour.
 But this was not allotted to him;
 for he died in about two hours after the above interview; signifying before he departed,
 that he was favoured to feel some relief in his spirit.
-

--- a/lives-of-primitive-quakers/modernized/17-chapter-16.adoc
+++ b/lives-of-primitive-quakers/modernized/17-chapter-16.adoc
@@ -227,7 +227,11 @@ from several of us.`"
 He then inserts a letter of Princess Elizabeth, in answer to two from him;
 and which is as follows:
 
+[.embedded-content-document.letter]
+--
+[.signed-section-context-open]
 "`Herford, May 2, 1677.
+
 "`This, friend, will tell you, that both your letters were very acceptable,
 together with your wishes for my obtaining those virtues,
 which may make me a worthy follower of our great King and Saviour, Jesus Christ.
@@ -237,11 +241,15 @@ neither did I expect any fruit of my letter to the Duchess of L. as I have
 expressed at the same time unto B. F. But since R. B. desired I should write it,
 I could not refuse him; nor omit to do anything that was judged conducing to his liberty,
 though it should expose me to the derision of the world.
-But this a mere moral man can reach at; the true inward graces are yet wanting in,
+But this a mere moral man can reach at; the true inward graces are yet lacking in,
 
+[.signed-section-closing]
 "`Your affectionate friend,
 
+[.signed-section-signature]
 "`Elizabeth.`"
+
+--
 
 On coming to the city where she resided,
 the friends made their arrival known to the princess,
@@ -440,4 +448,3 @@ and not the voice of any stranger whatever.
 
 "`So we left them in the love and peace of God,
 praying that they might be kept from the evil of this world.`"
-

--- a/lives-of-primitive-quakers/modernized/18-chapter-17.adoc
+++ b/lives-of-primitive-quakers/modernized/18-chapter-17.adoc
@@ -209,7 +209,7 @@ their eye should be to him, and not to man;
 that they might come into more silence of themselves,
 and a growth in that heavenly sense.
 That this was the work of the true ministry: not to keep people to themselves,
-and be ever teaching them; but to turn them to God, the newcovenant teacher,
+and be ever teaching them; but to turn them to God, the new covenant teacher,
 and to Christ, the great gospel minister.
 Thus did John, and thought it no dishonour that they left him to go to Christ.
 "`Behold the Lamb of God!`" said he, "`that takes away the sin of the world!`"
@@ -380,7 +380,8 @@ and returned, with great sense, humility and love.
 presence, love, and life of God, with all heavenly blessings,
 might descend and rest with, and upon them, then, and forever!`"
 
-* * * *
+[.asterism]
+'''
 
 The sweet and precious Christian love which animated the heart,
 and flowed from the lips of William Penn towards Princess Elizabeth, and her friend,
@@ -389,8 +390,13 @@ to testify his deep interest (more especially in the
 countess) by addressing to the latter an epistle,
 from which, before we conclude this memorial, some extracts may be acceptable:
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`For Anna Maria de Hornes, styled Countess of Hornes, at Herwerden in Germany.
 
+[.salutation]
 "`My Dear Friend,
 
 "`Oh that you may ever dwell in the sweet and tender sense of
@@ -420,7 +426,7 @@ prevail upon the civility of your nature; for they will oppress the innocent lif
 and bring grievous weights and burdens upon the soul.
 . . Oh beware of this compliance!
 Let me put you in mind of that sensible resolution, so frequently,
-and so passionately repeated by you: '`Il faut queje rompe!--il faut que je rompe.`'
+and so passionately repeated by you: '`Il faut queje rompe!--il faut que je rompe.`' [I must be broken. I must be broken]
 
 "`Now be assured,
 that till obedience be yielded to that present manifestation and conviction,
@@ -448,6 +454,8 @@ in the firmament of God's eternal kingdom.
 So let it be, Lord Jesus!
 Amen.`"
 
+--
+
 It may not be esteemed an irrelevant close to this interesting subject,
 if the following tribute from William Penn to
 the memory of his friend Princess Elizabeth,
@@ -456,7 +464,7 @@ the memory of his friend Princess Elizabeth,
 "`The late Princess Elizabeth of the Rhine, of right claims a memorial in this discourse;^
 footnote:[Serious dying, as well as living testimonies, chap.
 xxi. sect.
-34. "`No Cross no Crown.`"]
+34. [.book-title]#No Cross, No Crown.#]
 her virtue giving greater lustre to her name, than her quality,
 which yet was of the greatest in the German empire.
 She chose a single life, as freest of care,
@@ -524,4 +532,3 @@ footnote:[She died in 1680,
 and this passage was inserted in a second edition of "`No Cross, No Crown.`"]
 as much lamented as she had lived beloved of the people; to whose real worth I do,
 with religious gratitude for her kind reception, dedicate this memorial.`"
-

--- a/lives-of-primitive-quakers/modernized/19-chapter-18.adoc
+++ b/lives-of-primitive-quakers/modernized/19-chapter-18.adoc
@@ -10,12 +10,16 @@ by making applications to the Duke of York in their behalf,
 and that with a nobility of spirit,
 which exhibits an admirable specimen of the integrity of his character.
 
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
 Robert Barclay To The Princess Elizabeth.
 
-"`Theobald's, near London,
+[.signed-section-context-open]
+"`Theobald's, near London, 12th of the 7th month, 1677.
 
-12th of the 7th month, 1677.
-
+[.salutation]
 "`Dear Friend,
 
 "`By your letter of the last of the month past,
@@ -59,7 +63,7 @@ like that of a physician frequenting his patients for
 the increase or confirmation of their health;
 but must profess, that my converse with them is,
 to receive health and refreshment from them.`"--See Appendix
-to Barclay's Second Edition of I. Penington's Letters,
+to Barclay's Second Edition of [.book-title]#I. Penington's Letters,#
 p. 311.]
 
 "`What you write of the counsellor of the elector, and the other preachers,
@@ -94,10 +98,13 @@ If you see fit to salute that counsellor of the elector in my name, you may do i
 
 "`I shall add no more at present, but that I am your real and unfeigned friend,
 
+[.signed-section-signature]
 "`Robert Barclay.`"
 
+--
+
 "`The memoirs of the family,`" says John Barclay,^
-footnote:[See "`Jaffray and the Friends in Scotland,`" by J. Barclay, p. 415.]
+footnote:[See [.book-title]#Jaffray and the Friends in Scotland,# by J. Barclay, p. 415.]
 "`state in general terms,
 that the release of both the father and son +++[+++David and Robert Barclay]
 took place by an order from court, with a reprimand for meddling with either of them;
@@ -262,7 +269,7 @@ that she observed my grandfather that morning, before they were attacked,
 more pensive than usual; and that he told her it was his opinion,
 some unusual trial or exercise was to befal them that day; but when the affair happened,
 he enjoyed a remarkable serenity.`"^
-footnote:[Barclay's Friends in Scotland, p. 443.]
+footnote:[Barclay's [.book-title]#Friends in Scotland#, p. 443.]
 
 It was in the year 1690,
 that it pleased the Divine will to summons Robert Barclay from this world.
@@ -293,11 +300,17 @@ and others of the neighbourhood.
 The following letter from the pen of George Fox, addressed on this mournful occasion,
 to the widow, is too characteristic to be omitted.
 
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
 George Fox to Christian Barclay
 
+[.signed-section-context-open]
 "`28th of 10th month, 1690.^
 footnote:[George himself lived, not much above two weeks after the date of this epistle.]
 
+[.salutation]
 "`DEAR FRIEND!
 
 "`With my love to you and your children, and all the rest of friends, in the holy seed,
@@ -347,7 +360,10 @@ And so, the Lord God Almighty, settle and establish you and yours,
 upon the heavenly rock and foundation; that, as your children grow in years,
 they may grow in grace, and so in favour with the Lord.--Amen
 
+[.signed-section-signature]
 "`George Fox.`"
+
+--
 
 The character of Robert Barclay is best given in the words of a contemporary and friend;
 both of whom were combined in William Penn, who thus describes him:--
@@ -431,6 +447,10 @@ The conclusion of this address,
 more especially commends the noble sincerity of the writer's heart; while,
 to the credit of the king, it must be remembered,
 that he took no offence at the Christian freedom it displays:
+
+[.embedded-content-document.letter]
+--
+
 "`God has done great things for you,`" says Barclay.
 "`He has sufficiently shown you, that it is by him princes rule,
 and that he can pull down, and set up, at his pleasure.
@@ -470,9 +490,13 @@ that you may effectually turn to him, so as to improve your place and station,
 for his name.
 So wishes, so prays,
 
+[.signed-section-closing]
 "`Your faithful friend and subject,
 
+[.signed-section-signature]
 "`Robert Barclay.`"
+
+--
 
 This work was first published in Latin,
 when the author had only attained his twenty-eighth year,
@@ -495,4 +519,3 @@ But, a brief sketch of some of the leading subjects which it embraces,
 and with great force, and calmness of spirit, enlarges upon, may not be unacceptable;
 and which I, the rather feel inclined to offer to the reader's notice,
 in the hope of its inducing him to turn to, and consider the work itself.
-

--- a/lives-of-primitive-quakers/modernized/20-chapter-19.adoc
+++ b/lives-of-primitive-quakers/modernized/20-chapter-19.adoc
@@ -1,6 +1,6 @@
 == Chapter XIX
 
-The "`Apology for the True Christian Divinity,`" is an
+The [.book-title]#Apology for the True Christian Divinity#,`" is an
 enlarged discussion of fifteen propositions,
 which the author, in his address to the reader,
 describes as briefly comprehending the chief principles and doctrines of truth.
@@ -61,7 +61,7 @@ therefore it is not the primary or adequate rule of faith.
 
 "`Next, the very nature of the gospel itself declares,
 that the Scriptures cannot be the only and chief rule of Christians;
-else there should be no difference between the law and the gospel,which differ in this:
+else there should be no difference between the law and the gospel, which differ in this:
 in that the law being outwardly written, brings under condemnation,
 but has not life in it to save: whereas,
 the gospel as it declares and makes manifest the evil, so it, being an inward,
@@ -74,8 +74,7 @@ Hence, the apostle concludes, (Rom. 6:14) "`sin shall not have dominion over you
 for you are not under the law, but under grace`'--this grace then,
 which is an inward and not an outward law, is to be the rule of Christians.
 Hence,
-the apostle commends the elders of the church to it--(Acts 20{^
-}32)--to that spiritual law which makes free from sin,
+the apostle commends the elders of the church to it--(Acts 20:32)--to that spiritual law which makes free from sin,
 (Rom. 8:2) which was not outward--as Rom. 10:8--manifests; where,
 distinguishing it from the law, he says, "`it is nigh you; in your heart,
 and in your mouth;' and this is the word of truth which we preach.`"
@@ -244,11 +243,11 @@ Secondly.
 a measure of the light of his own Son;–a measure of grace;--or, a measure of the Spirit;
 which the scripture expresses by several names,
 as sometimes of '`The seed of the kingdom,`' (Matt. 13:18-
-19) "`The light that makes all things manifest,`' (Eph. 5:
-13) '`The word of God,`" (Rom. 10:17) or,
-'`Manifestation of the Spirit given to profit withal,' (1 Cor. 12:
-7) "`A talent,`' (Matt. 25:15) "`A little leaven,`" (Matt.
-xiii.33;) '`The gospel preached in every creature,`" (Col. 1:23)
+19) '`The light that makes all things manifest,`' (Eph. 5:
+13) '`The word of God,`' (Rom. 10:17) or,
+'`Manifestation of the Spirit given to profit withal,`' (1 Cor. 12:
+7) '`A talent,`' (Matt. 25:15) '`A little leaven,`' (Matt.
+xiii.33;) '`The gospel preached in every creature,`' (Col. 1:23)
 
 Thirdly.
 "`That God in, and by this light and seed, invites, calls, exhorts,
@@ -555,8 +554,8 @@ that this "`true light enlightens EVERY man that comes into the world.`"
 
 For what end this light is given, is expressed verse 7,
 where John is said to come for a witness to the light,
-"`that all men through it might believe; that is, through the light, di auton,
-which,`" he says, "`does very well agree with phogos, as being the nearest antecedent,
+"`that all men through it might believe; that is, through the light, __di auton__,
+which,`" he says, "`does very well agree with __phogos__, as being the nearest antecedent,
 though most translators (to make it suit with
 their own doctrine) have made it relate to John,
 as if all men were to believe through John`"--which was not possible,
@@ -707,10 +706,9 @@ as such; whom I take to be so great a man, that I profess freely,
 I had rather engage against a hundred Bellarmines, Hardings, and Stapletons,
 than with one Barclay`"--(Of Divine Light.--Tract II. p. 32.)^
 footnote:[Sir James Mackintosh also observes,
-with respect to Barclay and his "`Apology:`" "`Of those first who systematized,
+with respect to Barclay and his [.book-title]#Apology#: "`Of those first who systematized,
 and perhaps insensibly softened the Quakers' creed, was Barclay, a gentleman of Scotland,
 in his Apology for the Quakers; a masterpiece of ingenious reasoning,
 and a model of argumentative composition, which extorted praise from Bayle,
-one of the most acute and least fanatical of men.`"-- Mackintosh's Revolution in England,
+one of the most acute and least fanatical of men.`"-- Mackintosh's [.book-title]#Revolution in England#,
 p. 169.]
-

--- a/lives-of-primitive-quakers/modernized/21-chapter-20.adoc
+++ b/lives-of-primitive-quakers/modernized/21-chapter-20.adoc
@@ -1,6 +1,6 @@
 == Chapter XX
 
-AFTER his marriage, George Fox continued in the same line of ministerial service,
+After his marriage, George Fox continued in the same line of ministerial service,
 which seldom allowed him to continue long in one place.
 But the winter following this event, he was confined by illness at Enfield,
 during which time he describes his spiritual sufferings
@@ -158,6 +158,10 @@ and which he thus curiously expresses in a letter to his wife:
 he having sent her with one of her daughters home into the north as
 soon as he was taken prisoner and committed to Worcester jail.
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear Heart,`"
 
 "`You seemed to be a little grieved when I was speaking of prisons, and when I was taken.
@@ -166,7 +170,10 @@ I had a sight of my being taken prisoner; and when I was at B. Doiley's in Oxfor
 as I sat at supper, I saw I was taken: and I saw I had a suffering to undergo.
 But the Lord's power is over all, blessed be his holy name forever!
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 His companion in this imprisonment was Thomas Lower,
 who had married one of Margaret Fell's daughters, whose brother, Dr. Lower,
@@ -253,6 +260,10 @@ Although he was not amongst the friends who
 visited Princess Elizabeth upon this occasion,
 he addressed a long epistle to her, which he thus commences:
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Princess Elizabeth,
 
 "`I have heard of your tenderness towards the Lord and his holy truth,
@@ -281,10 +292,17 @@ and will be a teacher unto you at all times.`"
 He added, in a postscript, "`The bearer hereof, is a daughter-in-law of mine,
 that comes with Gertrude Dirick Nieson, and George Keith's wife, to give you a visit.
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 To this plain and unceremonious epistle, the princess returned the following reply:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear Friend,
 
 "`I cannot but have a tender love to those that love the Lord Jesus Christ,
@@ -293,12 +311,16 @@ Therefore your letter, and your friends' visit, have been both very welcome to m
 I shall follow their, and your counsel, as far as God will afford me light and unction,
 remaining still
 
+[.signed-section-closing]
 "`Your loving friend,
 
+[.signed-section-signature]
 "`Elizabeth.`"
 
-"`Hertford, 30th Aug.
-1677.`"
+[.signed-section-context-close]
+"`Hertford, 30th Aug. 1677.`"
+
+--
 
 On his return home,
 the labours of George Fox were more directed towards
@@ -350,4 +372,3 @@ and that he said to one of the noblemen who stood by,
 "`What shall we do for these people; the prisons are filled with them?`"
 But the person to whom he addressed himself, in order to draw him from the subject,
 and to divert him from his concern therein, led him into other discourse.
-

--- a/lives-of-primitive-quakers/modernized/22-chapter-21.adoc
+++ b/lives-of-primitive-quakers/modernized/22-chapter-21.adoc
@@ -58,6 +58,10 @@ and the other was of old people's going into the earth`" under
 the pressure of which exercise he wrote an epistle,
 which he addressed:
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`To all that profess the truth of God.
 
 "`My desires,`" he says, "`are, that you walk humbly in it:
@@ -74,6 +78,8 @@ and 'loading yourselves with thick clay.'
 and that which leads into a vain mind, and the fashions of the world,
 and into the earth;--though you have often had the rain fall upon your fields,
 you will but bring forth thistles, briars, and thorns, which are for the fire,`" etc.
+
+--
 
 His last work of this kind was an epistle of
 consolation and counsel to friends in Ireland,
@@ -102,7 +108,7 @@ with a manifest decline of strength, he retired at once to his bed,
 where he lay in much contentment and peace, and very sensible to the last.
 
 "`As he lived,`" says William Penn,^
-footnote:[In his preface to G. Fox's Journal, pp.
+footnote:[In his preface to [.book-title]#G. Fox's Journal#, pp.
 30 and 31.]
 "`so he died; feeling the same eternal power that had raised and preserved him,
 in his last moments.`"
@@ -377,9 +383,7 @@ and desired that they would let us have discourse with their priests, preachers,
 and teachers, and if they could prove us erroneous, then let them manifest it;
 but if our principles and doctrines be found according to the doctrine of Christ,
 and the apostles and saints in the primitive times, then let us have our liberty.^
-footnote:[From an old work, entitled "`A brief Collection of remarkable Passages,
-etc. relating to Margaret Fell,`" (p. 4,) and
-from which the present account of her is taken.]
+footnote:[From an old work, entitled [.book-title]#A brief Collection of remarkable Passages, etc. relating to Margaret Fell#, (p. 4,) and from which the present account of her is taken.]
 
 "`But,`" as the reader will not be surprised to hear,
 "`we could never get a meeting with any sort of them.`"
@@ -518,4 +522,3 @@ painful world-- it is all nothing to me,--for my Maker is my husband.`"
 
 A little before her departure, she called her daughter Rachel to her, saying,
 "`Take me in your arms`"--after which, she said, "`I am in peace!`"
-

--- a/lives-of-primitive-quakers/modernized/23-chapter-22.adoc
+++ b/lives-of-primitive-quakers/modernized/23-chapter-22.adoc
@@ -29,7 +29,7 @@ which you are derived;--illustrious in that true nobility which comes from God.
 
 "`What is it,`" says one of those truly illustrious ones,^
 footnote:[Isaac Penington.--See his Epistle to Friends, vol.
-ii p. 645, of his Works, in two vols.]--"`What is it to have a distinct name,
+ii p. 645, of his [.book-title]#Works#, in two vols.]--"`What is it to have a distinct name,
 or distinct meetings from the world, unless the power of the Lord be felt in your hearts,
 and his presence in your assemblies?`"
 What is it indeed, but setting up a broader mark than common,
@@ -97,7 +97,7 @@ No, the Lord knows,
 that the love of these things is daily rooted out of our hearts more and more,
 and we are a people whom the world cannot charge with covetousness or love of the world,
 with which all sorts of professors hitherto have been too justly chargeable.`"^
-footnote:[Isaac Penington, vol i. p. 302 of his Works.]
+footnote:[Isaac Penington, vol i. p. 302 of his [.book-title]#Works#.]
 
 Oh, friends! if in the least measure,
 a mightier hand than that frail one which traces these lines,
@@ -330,7 +330,7 @@ how beautiful to the enlightened eye is your memorial!
 You were God's building; and of that edifice which the Almighty rears,
 how truly does one amongst you thus express the character.^
 footnote:[Isaac Penington.
-See his Letters, published by J. Barclay, p. 84.]
+See his [.book-title]#Letters#, published by J. Barclay, p. 84.]
 
 "`Into your holy building, O God! into your heavenly building,
 into the spiritual Jerusalem, which you rear and build up in the Spirit,
@@ -367,4 +367,5 @@ and that only which you have received, and that not of man,
 nor by any of the natural workings of your own minds;
 "`but by the revelation of Jesus Christ!`"
 
+[.the-end]
 Finis

--- a/lives-of-primitive-quakers/original/01-introduction.adoc
+++ b/lives-of-primitive-quakers/original/01-introduction.adoc
@@ -1,4 +1,4 @@
-== Introductory Chapter.
+== Introductory Chapter
 
 "`We walk by faith,`" says the apostle, "`and not by sight;`" (2 Cor. 5:7)
 Now, the obedience which results from the walk of faith,
@@ -259,8 +259,5 @@ known as the Christian's glorious dwelling-place;
 and let all his loving children say, "`This God is our God for ever and ever,
 he will be our guide even unto death!`"
 
+[.signed-section-signature]
 M+++.+++ A. K.
-
-[.asterism]
-'''
-

--- a/lives-of-primitive-quakers/original/02-chapter-1.adoc
+++ b/lives-of-primitive-quakers/original/02-chapter-1.adoc
@@ -1,4 +1,4 @@
-== The Obedience of Faith.Chapter I.
+== Chapter I.
 
 In observing the dealings of Providence towards the human race,
 we generally discover that the most important consequences have resulted from what,
@@ -653,4 +653,3 @@ there was a secret unity in this little band of believers,
 which delivered them more than most other religious professors,
 from any fear or probability of being scattered, or brought to loss,
 under such a bereavement.
-

--- a/lives-of-primitive-quakers/original/03-chapter-2.adoc
+++ b/lives-of-primitive-quakers/original/03-chapter-2.adoc
@@ -292,7 +292,7 @@ and the next day, being a lecture, or a fast-day, he went to Ulverstone steeple-
 but came not in till the people were gathered.
 I and my children had been there a long time before.
 When they were singing before the sermon, he came in, and when they had done singing,
-he stood upon a seat or form,and desired that he might have liberty to speak,
+he stood upon a seat or form, and desired that he might have liberty to speak,
 and he that was in the pulpit said he might.^
 footnote:[If this intrusion on the part of George Fox,
 and this concession on the side of "`he that was in the pulpit,`" should,
@@ -729,4 +729,3 @@ when he meekly asks of his barbarous persecutors,
 for which of his good works were they about to stone him,
 "`for a good work we stone thee not; but for blasphemy!`"^
 footnote:[John 10:33.]
-

--- a/lives-of-primitive-quakers/original/04-chapter-3.adoc
+++ b/lives-of-primitive-quakers/original/04-chapter-3.adoc
@@ -29,6 +29,10 @@ to address a letter to the judges and court in his behalf; and which,
 as manifesting the view that was taken of his case by a judicious and educated man,
 it may be desirable to give at length.
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`To the judges of assize and gaol-delivery for the northern parts, sitting at Carlisle.
 
 "`You are raised up to do righteousness and justice,
@@ -71,7 +75,10 @@ and hath neither professed nor avowed them.^
 footnote:[G. Fox's Journal, folio edit.
 p. 101, 102.]
 
+[.signed-section-signature]
 "`Anthony Pearson.`"
+
+--
 
 But the friendly efforts of this gentleman were fruitless.
 It was resolved not to bring George Fox to trial; and he was left,
@@ -691,6 +698,10 @@ The result of these or other intercessions,
 occasioned an order to be sent down for their discharge;
 of which he gives the following copy:--
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Thursday, the 16th of October, at the Council at Whitehall.
 
 "`Ordered by his Highness the Lord Protector and the council,
@@ -702,7 +713,10 @@ or any of them (if any) may with most conveniency be taken off and discharged;
 and likewise to take order, that upon their being set at liberty, as aforesaid,
 they be forthwith sent to their respective homes.
 
+[.signed-section-signature]
 "`W. Jessop, clerk of the council.`"
+
+--
 
 Being thus aided,
 George Whitehead and his friends were not long before they received their freedom;
@@ -737,4 +751,3 @@ as he says had esteemed him either lost or dead;
 and finding the great hardships and persecutions he had undergone,
 they received him with great joy and kindness, and with less prejudice than heretofore,
 against the principles he had adopted, and the society to which he had united himself.
-

--- a/lives-of-primitive-quakers/original/05-chapter-4.adoc
+++ b/lives-of-primitive-quakers/original/05-chapter-4.adoc
@@ -96,7 +96,7 @@ But, besides that I may well hope to be forgiven for
 omitting to enter into so painful a detail,^
 footnote:[A minute account of the transactions alluded to,
 and of the severe trials of the primitive Quakers in general,
-may be found in Besse's Sufferings of Friends; the bare relation of which,
+may be found in [.book-title]#Besse's Sufferings of Friends#; the bare relation of which,
 occupies two closely printed folio volumes;
 and in which are records of cruelty on the one hand,
 and of Christian patience on the other, which, unless too well authenticated,
@@ -110,8 +110,13 @@ were the pleas made use of to trouble these unoffending people,
 if I present him with the following warrant, which, on one occasion,
 was issued against them by the magistrates.
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`City of Bristol.
 
+[.salutation]
 "`To the constables of the peace, of the ward of +++_______+++, and every of them.
 
 "`Forasmuch, as information hath been given unto us upon oath,
@@ -132,10 +137,14 @@ or any of them, and all other suspected persons,
 and to apprehend or bring them before us, or some of us,
 to be dealt with according to law.
 
+[.signed-section-context-open]
 "`Hereof fail not.
 Given the 25th of January, 1654.
 
+[.signed-section-signature]
 "`Signed, John Gunning, Mayor, and eight others have added their signatures.`"
+
+--
 
 Whilst at Bristol, on the occasion of the large meeting above mentioned,
 Edward Burrough was called to London,
@@ -251,7 +260,7 @@ and multitudes of the inhabitants of London wondering and gazing after an image 
 "`Edward Burrough caused to be printed;
 whereby he raised to himself a more lasting monument than by the
 erecting of a statue to his quondam friend Oliver Cromwell.`"^
-footnote:[Sewel's Histoiy, vol.
+footnote:[[.book-title]#Sewel's History#, vol.
 ii. p. 51. Lindfield edit.]
 
 Nor was it only with Oliver as the ruling authority,
@@ -358,7 +367,7 @@ that we love righteousness and hate iniquity, and that we now suffer for thy hol
 and for thy honour and justice, and for thy truth and holiness!
 O Lord, thou knowest we are resolved to perish, rather than to lose one grain hereof!
 Amen, amen!`"^
-footnote:[Sewel's History, (Lindfield edition,) vol.ii.pp. 420, 425.]
+footnote:[[.book-title]#Sewel's History#, (Lindfield edition,) vol.ii.pp. 420, 425.]
 Much more is subjoined;
 but the foregoing extracts may suffice to show the
 simple integrity with which he pleaded the case;
@@ -535,4 +544,3 @@ Nay. And now thou art freed from the temptations of him who hath the power of de
 and art freed from thy outward enemies,
 who hated thee because of the life that dwelt in thee,
 and remainest at the right hand of God, where there is joy and pleasure for evermore!`"
-

--- a/lives-of-primitive-quakers/original/06-chapter-5.adoc
+++ b/lives-of-primitive-quakers/original/06-chapter-5.adoc
@@ -188,8 +188,10 @@ rejoicing and praising God and the Lamb, that lives for ever and for evermore.
 Amen! "`Your dear brother in the patience and sufferings of Christ,
 who abounds in perfect love to all the faithful flock of Christ everywhere.
 
+[.signed-section-signature]
 "`F. H.
 
+[.signed-section-context-close]
 "`From Appleby gaol, the place of my rest, where my days and hours are pleasant unto me;
 the 4th of the 5th month, 1664.`"
 
@@ -378,4 +380,3 @@ let them know that I die in the faith which I lived in, and suffered for.`"
 After a few words of prayer to God, he spake no more;
 but entered into his blissful and everlasting rest, in the fiftieth year of his age,
 having been a prisoner for the testimony of Jesus, nearly five years.
-

--- a/lives-of-primitive-quakers/original/07-chapter-6.adoc
+++ b/lives-of-primitive-quakers/original/07-chapter-6.adoc
@@ -691,6 +691,7 @@ who hath thus far set me free to praise his righteousness and his mercy!
 And to the eternal, invisible, pure God, over all, be fear, obedience, and glory,
 for evermore!-- Amen!
 
+[.signed-section-signature]
 "`James Naylor.`"
 
 In another paper, wherein he relates more circumstantially,
@@ -885,4 +886,3 @@ who through death obtained this resurrection, and eternal, holy life!`"
 Such was the end of James Naylor; who, in his forty-fourth year, "`chastened,
 but not killed-- cast down, but not destroyed`"--through much tribulation, entered,
 we may humbly hope, into the kingdom of God.`"
-

--- a/lives-of-primitive-quakers/original/08-chapter-7.adoc
+++ b/lives-of-primitive-quakers/original/08-chapter-7.adoc
@@ -290,7 +290,10 @@ is accounted for; whilst upon any other ground it is unaccountable.
 
 And as, according to the poet's statement respecting ambition:
 
+[verse]
+____
 "`It oft o'er leaps itself, and falls on t'other side,`"
+____
 
 So, it commonly happens with sinister designs for individual security.
 This excessive determination, on the part of the inhabitants of Boston,
@@ -373,7 +376,7 @@ departed from the jurisdiction for that time; but Robinson and Stevenson,
 though they quitted Boston, did not feel themselves at liberty to quit the jurisdiction,
 though their lives were at stake;
 they therefore went to Salem and other places thereabouts, to visit their friends,
-and stablish them in the faith.
+and establish them in the faith.
 
 It was not long before they were again in custody, and Mary Dyar returning also,
 they were all three imprisoned once more at Boston.
@@ -775,6 +778,9 @@ being an inhabitant of New England, had been banished on pain of death,
 if ever he returned thither.
 To him the king granted a deputation, with full power to carry the following mandamus:--
 
+[.embedded-content-document.letter]
+--
+[.signed-section-context-open]
 "`Charles R.
 
 "`Trusty and well beloved, we greet you well.
@@ -793,19 +799,19 @@ to the end that such course may be taken with them here,
 as shall be agreeable to our laws, and their demerits.
 And for so doing, these our letters shall be your sufficient warrant and discharge.
 
-"`Given at our court at Whitehall, the 9th day of September, 1661,
-in the thirteenth year of our reign.
+[.signed-section-closing]
+"`Given at our court at Whitehall, the 9th day of September, 1661, in the thirteenth year of our reign.
 
+[.signed-section-closing]
 "`By his Majesty's command,
 
+[.signed-section-signature]
 "`William Morris.
 
-"`Addressed: To our trusty and well-beloved John Endicot, Esq.,
-and to all and every other the governor, or governors of our plantations of New England,
-and of all the colonies thereunto belonging, that now are, or hereafter shall be;
-and to all and every the ministers and officers
-of our said plantations and colonies whatsoever,
-within the continent of New England.`"
+[.postscript]
+"`Addressed: To our trusty and well-beloved John Endicot, Esq., and to all and every other the governor, or governors of our plantations of New England, and of all the colonies thereunto belonging, that now are, or hereafter shall be; and to all and every the ministers and officers of our said plantations and colonies whatsoever, within the continent of New England.`"
+
+--
 
 This mandamus being obtained, no time was lost in dispatching it; and in six weeks' time,
 Samuel Shattock, the bearer of it, entered the Bay of Boston, on a Sunday morning.
@@ -841,4 +847,3 @@ he returned to the two friends, and said, "`We shall obey his majesty's command.
 The master of the ship afterwards giving liberty to the passengers to come ashore,
 they met together with their friends of the town, and offered up praises to God,
 for this wonderful deliverance.
-

--- a/lives-of-primitive-quakers/original/09-chapter-8.adoc
+++ b/lives-of-primitive-quakers/original/09-chapter-8.adoc
@@ -400,4 +400,3 @@ in drawing to the conclusion of his address to them, "`consider your cause again
 in a more meek and upright spirit; and ye yourselves will easily see, how in your heart,
 ye have been mistaken, and dealt more injuriously with others,
 than ye yourselves were ever dealt with.`"
-

--- a/lives-of-primitive-quakers/original/10-chapter-9.adoc
+++ b/lives-of-primitive-quakers/original/10-chapter-9.adoc
@@ -128,7 +128,7 @@ and the gaoler being at the door, "`I gave him something,`" he says,
 and he let me pass out without interruption.
 But soon after, Isaac Penington coming to visit them, he stopped him,
 and caused him to be made a prisoner.^
-footnote:[G. Fox's Journal, p. 419.]
+footnote:[[.book-title]#G. Fox's Journal#, p. 419.]
 
 One of the most unrelenting foes of this excellent man, was the Earl of Bridgewater,
 who upon some account or another,
@@ -137,8 +137,13 @@ more than once, was the cause of his imprisonment.
 It was during one of these occasions, that he addressed a letter to him,
 from which a few extracts are here made.
 
-"`To The Earl of Bridgewater.
+[.embedded-content-document.letter]
+--
 
+[.letter-heading]
+To The Earl of Bridgewater.
+
+[.salutation]
 "`Friend,
 
 "`It is the desire of my heart to walk with God, in the true fear of his name,
@@ -169,6 +174,8 @@ These things very nearly concern thee.
 Oh, wait upon God for his true light, that thou mayest not be deceived about them;
 because thy loss thereby will be so great and irreparable.`"
 
+--
+
 But however painful to the nature of the "`outward man`" these sufferings might be,
 the "`hidden man of the heart`" was thereby perfected, in no ordinary degree,
 in the case of Isaac Penington.
@@ -176,14 +183,14 @@ Most of his inestimable letters, as well as the above,
 were written within the walls of a prison; and of the preciousness of these testimonies,
 many, then unborn, have tasted with profit and delight.
 
-Yes, good and faithful servant!--well-instructed scribe!--bringing forth out of thy treasures,
+Yes, good and faithful servant! --well-instructed scribe!-- bringing forth out of thy treasures,
 things new and old--thou hast fed many!
 Be thy just memory blessed! and let a heart that owes thee much, thus,
 in most true and tender love, record its gratitude.
 
 Of his deportment in the tribulations that befel him,
 there are many pleasing testimonies; but I select one only from the pen of Robert Jones,^
-footnote:[Prefixed to the Works of Penington.]
+footnote:[Prefixed to the [.book-title]#Works of Penington#.]
 his friend, and often, fellow-prisoner.
 
 "`What shall I say?`"
@@ -210,6 +217,10 @@ whose faithfulness rendered them worthy of it.
 The following letter from him to George Fox,
 exemplifies this amiable disposition very pleasingly:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear G. F.
 
 "`I feel the tender mercy of the Lord, and some portion of that brokenness, fear,
@@ -229,14 +240,19 @@ and may walk in perfect humility and tenderness of spirit before him, all my day
 Be helpful to me in tender love, that I may feel settlement and stability in the truth;
 and perfect separation from, and dominion in the Lord, over all that is contrary thereto.
 
+[.signed-section-signature]
 "`I. P.
 
-"`Aylesbury Gaol, "`15th Fifth month, 1667.`"
+[.signed-section-context-close]
+"`Aylesbury Gaol, 15th Fifth month, 1667.`"
 
+[.postscript]
 "`I entreat thy prayers for my family, that the name of the Lord may be exalted,
 and his truth flourish therein.
 Dear G. F., indeed my soul longs for the pure, full,
 and undisturbed reign of the Life in me.`"
+
+--
 
 Being well fitted and prepared by sanctified suffering, he was ready for death; and,
 as William Penn describes him, under that exigency, "`had nothing else to do but to die,
@@ -370,7 +386,7 @@ when at any time I looked on the man, I was hardly able to forbear disdaining th
 but on the other hand,
 when the eye of my spirit beheld the power and glory of the Lord in them,
 I could hardly forbear over-esteeming, and exalting them.`"^
-footnote:[Penington's Works, vol.
+footnote:[[.book-title]#Penington's Works,# vol.
 i. p. 632.]
 
 But is not this the way of the Lord,--the invariable way?--we would ask.
@@ -599,5 +615,5 @@ After a few more words, she concludes by saying,
 "`this testimony to dear Isaac Penington,
 is from the greatest loser of all that had a share in his life,
 
+[.signed-section-signature]
 "`Mary Penington.`"
-

--- a/lives-of-primitive-quakers/original/11-chapter-10.adoc
+++ b/lives-of-primitive-quakers/original/11-chapter-10.adoc
@@ -282,72 +282,51 @@ upon the whole, was their portion in this dark and cloudy day,
 by offering to the reader a few stanzas of Catherine's humble, but very sweet poetry,
 looking at it in spirit.
 
+[verse]
+____
 HYMN TO GOD.^
 footnote:[Only a selection is given from this poem.]
 
 All praise to him that hath not put,
-
 Nor cast me out of mind;
-
 Nor yet his mercy from me shut,
-
 As I could ever find.
 
 Oh none is like unto the Lamb,
-
-"`Whose beauty shineth bright!
-
+Whose beauty shineth bright!
 O! glorify his holy name,
-
 His majesty and might.
 
 My soul, praise thou the only God,
-
- A fountain pure and clear;
-
+A fountain pure and clear;
 Whose crystal streams spread all abroad,
-
 And cleanseth far and near.
 
 My sweet, and dear beloved one,
-
 Whose voice is more to me
-
 Than all the glory of the earth,
-
 Or treasures I can see.
 
 My soul, praise thou the Lord I say,
-
 Praise him with joy and peace;
-
 My spirit and mind, both night and day,
-
 Praise him and never cease.
 
 Oh, praises, praises, to our God!
-
 Sing praises to our King;
-
 O teach the people, all abroad,
-
 His praises for to sing.
 
 A Sion song of glory bright,
-
 That doth shine out so clear;
-
 O manifest it in the sight
-
 Of nations far and near.
 
 That God may have his glory due,
-
 His honour and his fame;
-
 And all his saints may sing anew
-
 The praises of his name.
+____
 
 It is worthy of observation, and certainly tending to spiritual progress,
 to consider how much the soul thrives in the exercise of praise.
@@ -376,7 +355,7 @@ and brother,`"--telling him that she has unity and fellowship with him day and n
 "`Oh my dear husband and children,`" she says,
 "`how often have I poured out my soul to the everlasting Father for you,
 with rivers of tears night and day,
-that you might be kept pure and single in the sight of our God . . .
+that you might be kept pure and single in the sight of our God. . .
 
 "`My dear hearts, you do not want teaching; you are in a land of blessedness,
 which floweth with milk and honey! among the faithful
@@ -395,8 +374,7 @@ that the crown of life and immortality comes to be obtained.
 The Lord hath exercised my patience, and tried me to the uttermost; to his praise,
 and my eternal comfort, who hath not been wanting to us in anything, in his own due time.
 We are witnesses that he can provide a table in the wilderness,
-both spiritual and temporal.
-. . .
+both spiritual and temporal. . .
 
 "`In our deepest affliction, when I looked for every breath to be the last,
 I could not wish I had not come over the sea;
@@ -560,4 +538,3 @@ all that I desire of you is, that when you pray to God,
 you will remember me in your prayers.'
 
 "`And so they parted.`"
-

--- a/lives-of-primitive-quakers/original/12-chapter-11.adoc
+++ b/lives-of-primitive-quakers/original/12-chapter-11.adoc
@@ -18,7 +18,13 @@ to exhort him to exercise mercy and forgiveness towards his enemies,
 and to warn him to restrain the profaneness and
 looseness that was got up in the nation on his return.`"
 
-"`To The King.`"
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
+To The King.
+
+[.salutation]
 "`King Charles,
 
 "`Thou entered not into this nation by sword, nor by victory of war,
@@ -48,7 +54,10 @@ in which we have peace, and that we may not be brought into ungodliness by them.
 Hear, and consider, and do good in thy time, whilst thou hast power.
 Be merciful and forgive; that is the way to overcome, and obtain the kingdom of Christ.
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 At the time of writing this epistle, George was a prisoner in Lancaster Castle;
 whither he had been roughly taken,
@@ -64,6 +73,9 @@ with the addition of his holding fanatic
 opinions,) he answered it by a sort of manifesto,
 which is greatly too prolix for insertion as it stands;
 but from which a few extracts may be acceptable.
+
+[.embedded-content-document.letter]
+--
 
 "`I am a prisoner at Lancaster, committed by Justice Porter.
 A copy of the mittimus I cannot get; but such expressions I am told are in it,
@@ -94,11 +106,16 @@ but all are of a mad, foolish, furious spirit, that wrestle with flesh and blood
 and with carnal weapons, in their furiousness, foolishness and rage.
 This is not the Spirit of God, but of error, that persecutes in a mad, blind zeal,
 like Nebuchadnezzar and Saul.`"
+
 He subscribes this paper,
 
+[.signed-section-closing]
 "`From an innocent sufferer in bonds, and close prisoner in Lancaster Castle; called
 
+[.signed-section-signature]
 "`George Fox.`"
+
+--
 
 In the meantime many exertions were making on the part of his friends,
 towards his emancipation; Margaret Fell going herself to London,
@@ -221,38 +238,42 @@ many friends being in prison,
 because they could not burden their consciences
 by taking the oath of allegiance and supremacy.
 
-"`King.
-But why cannot you swear?
+[.discourse-part]
+"`__King__--But why cannot you swear?
 for an oath is a common thing amongst men to any engagement?
 
-"`R. H. Yes: it is manifest, and we have seen by experience,
+[.discourse-part]
+"`__R. H.__--Yes: it is manifest, and we have seen by experience,
 that it is so common amongst men to swear, and engage either for, or against things,
 that there is no regard taken to it, nor fear of an oath.
 That therefore, which we speak of, in the truth of our hearts,
 is more than what they can swear.
 
-"`King.
-But can you promise before the Lord?
+[.discourse-part]
+"`__King__--But can you promise before the Lord?
 which is the substance of an oath.
 
-"`R. H. Yes; what we do affirm, we can promise before the Lord,
+[.discourse-part]
+"`__R. H.__--Yes; what we do affirm, we can promise before the Lord,
 and take him to our witness in it.
 But our so promising hath not been accepted;
 but the ceremony of an oath they have stood for; without which,
 all other things were accounted of no effect.
 
-"`King.
-But how may we know from your words, that you will perform?
+[.discourse-part]
+"`__King__--But how may we know from your words, that you will perform?
 
-"`R. H. By proving us: for they that swear, are not known to be faithful,
+[.discourse-part]
+"`__R. H.__--By proving us: for they that swear, are not known to be faithful,
 but by proving them; and so we, by those that have tried us,
 are found to be truer in our promises, than others by their oaths;
 and to those that do yet prove us, we shall appear the same.
 
-"`King.
-Pray what is your principle?
+[.discourse-part]
+"`__King__--Pray what is your principle?
 
-"`R. H. Our principle is this;
+[.discourse-part]
+"`__R. H.__--Our principle is this;
 that Jesus Christ is 'the true light that enlighteneth every one that
 cometh into the world,' that all men through him might believe;
 and that they are to obey and follow this light, as they have received it;
@@ -263,14 +284,16 @@ Some further discourse ensued upon the subject of the sacrament,
 in which the lords in waiting also joined; after which, the king asked him,
 "`How know you that you are inspired by the Lord?`"
 
-"`R. H. According as we read in the scriptures,
+[.discourse-part]
+"`__R. H.__--According as we read in the scriptures,
 that 'the inspiration of the Almighty giveth understanding,' so, by his inspiration,
 is an understanding given us of the things of God.'
 
 One of the lords in waiting then inquired,`" How
 do you know that you are led by the true spirit?`
 
-"`R. H. This we know, because the Spirit of truth reproves the world of sin; and by it,
+[.discourse-part]
+"`__R. H.__--This we know, because the Spirit of truth reproves the world of sin; and by it,
 we are reproved of sin, and are also led from sin unto righteousness,
 and obedience of truth; by which effects, we know it is the true Spirit;
 for the spirit of the wicked one doth not lead into such things.`"
@@ -340,4 +363,3 @@ notwithstanding all the depredations they had
 suffered at the hands of these their enemies,
 friends could praise God, "`that they had a kettle, a platter, a horse,
 and a plough still.`"
-

--- a/lives-of-primitive-quakers/original/13-chapter-12.adoc
+++ b/lives-of-primitive-quakers/original/13-chapter-12.adoc
@@ -167,13 +167,16 @@ to ratify and confirm truth between them.`"
 Thirdly: in what case was an oath to be used?
 He specifies four occasions in which it was chiefly required.
 
+[.numbered]
 I+++.+++ In case of a promise or vow to God.
 
+[.numbered]
 II. In case of promise to man.
 
-III.
-In case of pronouncing or declaring the truth of a thing, etc.
+[.numbered]
+III. In case of pronouncing or declaring the truth of a thing, etc.
 
+[.numbered]
 IV. In case of controversy between parties, where it could not be determined,
 but by taking the confession of one party for truth.
 
@@ -183,13 +186,17 @@ comprise the substance of the rest.
 He then speaks of four states or conditions of the soul, since the creation,
 preparatory to his applying the matter to the case of friends.
 
+[.numbered]
 1+++.+++ A state of integrity, wherein man could not lie nor deceive.
 
+[.numbered]
 2+++.+++ A state of deep captivity to evil, etc.
 
+[.numbered]
 3+++.+++ A state of shadowy redemption from evil, etc.,
 wherein were figures of heavenly things--but not the very things themselves.
 
+[.numbered]
 4+++.+++ A state of true redemption, which state, he thanks God,
 is (after a long night of apostasy) again brought forth.
 
@@ -259,6 +266,10 @@ with most others of the Society, was often made the subject of suffering.
 I allude to the question about the payment of tithes;
 upon which he thus expresses himself in a letter addressed to one James Eeles;
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Friend,
 
 "`God is my witness, to whom I must give an account of all my actions,
@@ -277,7 +288,12 @@ what God's power has disannulled,--indeed I do not see;
 nor can I be subject to any human law or authority in this thing,
 without sinning against God, and incurring his wrath upon my soul.
 
+--
+
 He then observes, that Christ sent forth his ministers without tithes.
+
+[.embedded-content-document.letter]
+--
 
 "`Now tithes,`" he continues, "`were set up in the dark time of popery,
 and not by the gospel light; and they who know the gospel light,
@@ -292,9 +308,10 @@ both which ministry and its maintenance, is to be denied and witnessed against,
 by those whom he calls forth to testify to his truth in these things.`"^
 footnote:[Penington's Letters, p. 157.]
 
+--
+
 Such being the views of Isaac Penington, and of the members of the Society in general,
 upon these questions, it appears a necessary consequence,
 that they should resolutely maintain the ground they had taken,
 and willingly devote themselves to persecution, even had it been to death,
 rather than violate such truly pure and exalted principles.
-

--- a/lives-of-primitive-quakers/original/14-chapter-13.adoc
+++ b/lives-of-primitive-quakers/original/14-chapter-13.adoc
@@ -123,8 +123,7 @@ on the part of government, accompanied every fresh plot.
 
 Amongst those who were at this time in prison, Margaret Fell was one;
 of whose examination at Lancaster assizes, there is an account preserved,^
-footnote:[In a "`Brief Collection of Remarkable Passages,
-etc relating to Margaret Fell,`" p. 276.]
+footnote:[In a [.book-title]#"`Brief Collection of Remarkable Passages, etc relating to Margaret Fell,`"# p. 276.]
 which, taken in conjunction with that of George Fox,
 respecting his trial at the same place, and time, and on the same occasion,
 affords a curious specimen of the calm, and somewhat amusing inflexibility,
@@ -496,4 +495,3 @@ and the bad usage I had received in prison;
 and also that I was informed that no man could deliver me but he;`" which statement,
 in connexion with the representations of some of his friends,
 at length succeeded in procuring an order for his release.
-

--- a/lives-of-primitive-quakers/original/15-chapter-14.adoc
+++ b/lives-of-primitive-quakers/original/15-chapter-14.adoc
@@ -153,17 +153,21 @@ And to show that there remained a sincerity in the man,
 after his mind came to be settled, he wrote a letter to some friends in London,
 wherein he hath these words following:--
 
-"`'I dare not much stir up or down any way, for people's looking at what was done;
-lest the Lord should be offended, etc.
+[.embedded-content-document.letter]
+--
 
-"`'I have been much tempted and exercised; yet, through mercy,
+"`'I dare not much stir up or down any way, for people's looking at what was done;
+lest the Lord should be offended, etc. I have been much tempted and exercised; yet, through mercy,
 have found help in the needful time.
 Whatsoever slips or failings friends saw in me, in the time I was with them,
 I would have none take notice of; for I was under great exercises,
 and often ran too fast, which the Lord in his due time, gave me a sight of.
 In the love of my Father, farewell!
 
+[.signed-section-signature]
 "`'T. I. '`"
+
+--
 
 Nor was it only to this person,
 that a foreshadowing was vouchsafed of this fearful calamity: George Fox, in his Journal,
@@ -220,4 +224,3 @@ where taking leave of each other in the Lord, we parted;
 betaking ourselves each to our several services;
 Margaret returning homewards to the north,
 and I passing on in the work of the Lord as before.`"
-

--- a/lives-of-primitive-quakers/original/16-chapter-15.adoc
+++ b/lives-of-primitive-quakers/original/16-chapter-15.adoc
@@ -26,7 +26,7 @@ ever afterwards engaged in military concerns.
 
 Being now, by the situation of public affairs,
 incapable of rendering any further service to his prince, he retired to Gordonstoun;
-between which place, and Edinburgh, he chiefly passed his time, until the year 1C63;
+between which place, and Edinburgh, he chiefly passed his time, until the year 1663;
 at which period he experienced the trial of losing his excellent wife.^
 footnote:[He had married Catherine Gordon, eldest daughter of Sir Robert Gordon,
 of Gordonstoun, second son to the Earl of Sutherland.]
@@ -217,7 +217,7 @@ I felt a secret power among them, which touched my heart; and as I gave way unto
 I found the evil weakening in me, and the good raised up;
 and so I became thus knit and united unto them,
 hungering more and more after the increase of this power and life,
-whereby I might feel myself perfectly redeemed!`" -- (Barclay's Works, vol.
+whereby I might feel myself perfectly redeemed!`" -- ([.book-title]#Barclay's Works#, vol.
 ii. p. 353--356.)
 
 It is not easily believed,
@@ -263,8 +263,7 @@ resist the insinuations that were used to proselyte me to that way,
 I became quickly defiled with the pollutions thereof; until it pleased God,
 in his rich love and mercy, to deliver me out of those snares,
 and to give me a clear understanding of the evil of that way.`"^
-footnote:["`Treatise on Universal Love.`"--Barclay's Works, vol.
-iii. p. 186.]
+footnote:[Treatise on Universal Love, from [.book-title]#Barclay's Works#, vol.iii. p. 186.]
 
 About the year 1670, Robert Barclay married Christian Molleson,
 a very estimable young woman, united in profession with friends.
@@ -285,7 +284,7 @@ that I can say in the fear of the Lord,
 that I have received a charge from him to love thee,
 and for that I know his love is much towards thee, and his blessing and goodness is,
 and shall be unto thee, so long as thou abidest in a true sense of it.`"^
-footnote:[The Friends in Scotland, by John Barclay, p. 295.]
+footnote:[[.book-title]#The Friends in Scotland#, by John Barclay, p. 295.]
 
 It was the lot of Robert Barclay, in common with many others amongst friends,
 to feel himself commanded by the Divine will,
@@ -355,6 +354,10 @@ that it was by no concessions inimical to truth on their side, we have ample tes
 in a noble appeal made in their joint names, to the magistrates who had committed them,
 and which begins thus:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Friends,
 
 "`Our case being as it was, and as some of us fully represented it to you,
@@ -373,7 +376,12 @@ your iniquities in this and the like cases,
 and you cannot vanquish us.
 You imagine a vain thing, and you will herein weary yourselves with very vanity.`"
 
+--
+
 After some close expostulations, it thus concludes:--
+
+[.embedded-content-document.letter]
+--
 
 "`Well! we ask nothing of you, but that you come to a sense of your past way,
 that you may not fall into the like for the future.
@@ -386,9 +394,12 @@ We are, as regards our testimony, and for its sake, well contented, well pleased
 well satisfied to be here; our bonds are not grievous unto us,
 glory to the Lord for ever! who hath not been, and who is not wanting to us.
 
+[.signed-section-signature]
 "`John Swintoune, William Napiek, John Milne, Robert Barclay, James Nuccoll,
 William Low.`"^
-footnote:[Barclay's Friends in Scotland, p. 315-- 316.]
+footnote:[[.book-title]#Barclay's Friends in Scotland#, p. 315-- 316.]
+
+--
 
 Whilst the younger Barclay was thus valiantly contending for the truth,
 and also suffering in its behalf, David Barclay, the father,
@@ -425,8 +436,13 @@ by the tenor of which epistle,
 she seems to have received information of somewhat an exaggerated kind,
 respecting his case.
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Herford, December 19th, 1676.
 
+[.salutation]
 "`Dear Brother,
 
 "`I have written to you some months ago, by Robert Barclay, who passed this way,
@@ -445,7 +461,7 @@ etc.--'I should admire,`" she says,
 in a former letter to R. B.--"`I should admire God's providence,
 if my brother could be a means of releasing your father and forty more in Scotland:
 having promised to do his best,
-I know he will perform it.`"-- Barclay's Friends in Scotland, p. 354.]
+I know he will perform it.`" From [.book-title]#Barclay's Friends in Scotland,# p. 354.]
 to the council of Scotland,
 he has been clapped up in prison with the rest of his friends,
 and they threaten to hang him (at least those they call preachers
@@ -461,7 +477,10 @@ than in a sensible compassion of the innocent sufferers.
 You will act herein according to your own discretion:
 and I beseech you still consider me as yours,
 
+[.signed-section-signature]
 "`Elizabeth.`"
+
+--
 
 It does not appear that the above application was speedily, if at all, influential,
 in the liberation of Robert Barclay; who, with his friends,
@@ -498,6 +517,9 @@ After reminding them of the "`blessed visitation`" and
 tender mercy of the Lord towards them as a people,
 he says,
 
+[.embedded-content-document.letter]
+--
+
 "`Indeed the Lord is with us--what can we desire more?
 preparing us for himself, preserving us in the life of his blessed truth,
 building us up more and more,
@@ -527,9 +549,13 @@ whose breathings are to God for you, and his praises unto him,
 through the sense of his being with you, and daily showing mercy to you,
 upholding and preserving you in the midst of your sore trials and afflictions.
 
+[.signed-section-signature]
 "`Isaac Penington.`"
 
+[.signed-section-context-close]
 "`London, 5th of 5th month, 1676.`"
+
+--
 
 One of the pretences made use of by the authorities of Scotland,
 for their cruel proceedings against the Quakers,
@@ -549,7 +575,7 @@ the magistrates assembled a large concourse of the citizens, and with much parad
 went forth to meet them, expressing all the usual tokens of profound respect;
 so that on that occasion,
 "`the whole town appeared in a manner taken up with the grandeur of the ceremony.`"^
-footnote:[ J. Barclay's Friends in Scotland, p. 385.]
+footnote:[[.book-title]#J. Barclay's Friends in Scotland#, p. 385.]
 
 On reading which,
 the mind involuntarily recurs to the homely proverb of "`one may steal a horse,
@@ -753,4 +779,3 @@ he now wished on that day, to bear witness in their favour.
 But this was not allotted to him;
 for he died in about two hours after the above interview; signifying before he departed,
 that he was favoured to feel some relief in his spirit.
-

--- a/lives-of-primitive-quakers/original/17-chapter-16.adoc
+++ b/lives-of-primitive-quakers/original/17-chapter-16.adoc
@@ -227,7 +227,12 @@ from several of us.`"
 He then inserts a letter of Princess Elizabeth, in answer to two from him;
 and which is as follows:
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`Herford, May 2, 1677.
+
 "`This, friend, will tell you, that both your letters were very acceptable,
 together with your wishes for my obtaining those virtues,
 which may make me a worthy follower of our great King and Saviour, Jesus Christ.
@@ -240,9 +245,13 @@ nor omit to do any thing that was judged conducing to his liberty,
 though it should expose me to the derision of the world.
 But this a mere moral man can reach at; the true inward graces are yet wanting in
 
+[.signed-section-closing]
 "`Your affectionate friend,
 
+[.signed-section-signature]
 "`Elizabeth.`"
+
+--
 
 On coming to the city where she resided,
 the friends made their arrival known to the princess,
@@ -441,4 +450,3 @@ and not the voice of any stranger whatever.
 
 "`So we left them in the love and peace of God,
 praying that they might be kept from the evil of this world.`"
-

--- a/lives-of-primitive-quakers/original/18-chapter-17.adoc
+++ b/lives-of-primitive-quakers/original/18-chapter-17.adoc
@@ -210,7 +210,7 @@ their eye should be to him, and not to man;
 that they might come into more silence of themselves,
 and a growth in that heavenly sense.
 That this was the work of the true ministry: not to keep people to themselves,
-and be ever teaching them; but to turn them to God, the newcovenant teacher,
+and be ever teaching them; but to turn them to God, the new covenant teacher,
 and to Christ, the great gospel minister.
 Thus did John, and thought it no dishonour that they left him to go to Christ.
 "`Behold the Lamb of God!`" said he, "`that taketh away the sin of the world!`"
@@ -380,7 +380,8 @@ and returned, with great sense, humility and love.
 presence, love, and life of God, with all heavenly blessings,
 might descend and rest with, and upon them, then, and for ever!`"
 
-* * * *
+[.asterism]
+'''
 
 The sweet and precious Christian love which animated the heart,
 and flowed from the lips of William Penn towards Princess Elizabeth, and her friend,
@@ -389,8 +390,13 @@ to testify his deep interest (more especially in the
 countess) by addressing to the latter an epistle,
 from which, ere we conclude this memorial, some extracts may be acceptable:
 
+[.embedded-content-document.letter]
+--
+
+[.signed-section-context-open]
 "`For Anna Maria de Hornes, styled Countess of Hornes, at Herwerden in Germany.
 
+[.salutation]
 "`My Dear Friend,
 
 "`Oh that thou mayest ever dwell in the sweet and tender sense
@@ -448,6 +454,8 @@ in the firmament of God's eternal kingdom.
 So let it be, Lord Jesus!
 Amen.`"
 
+--
+
 It may not be esteemed an irrelevant close to this interesting subject,
 if the following tribute from William Penn to
 the memory of his friend Princess Elizabeth,
@@ -457,7 +465,7 @@ the memory of his friend Princess Elizabeth,
 of right claimeth a memorial in this discourse;^
 footnote:[Serious dying, as well as living testimonies, chap.
 xxi. sect.
-34. "`No Cross, No Crown.`"]
+34. [.book-title]#No Cross, No Crown.#]
 her virtue giving greater lustre to her name, than her quality,
 which yet was of the greatest in the German empire.
 She chose a single life, as freest of care,
@@ -525,4 +533,3 @@ footnote:[She died in 1680,
 and this passage was inserted in a second edition of "`No Cross no Crown.`"]
 as much lamented as she had lived beloved of the people; to whose real worth I do,
 with religious gratitude for her kind reception, dedicate this memorial.`"
-

--- a/lives-of-primitive-quakers/original/19-chapter-18.adoc
+++ b/lives-of-primitive-quakers/original/19-chapter-18.adoc
@@ -10,12 +10,16 @@ by making applications to the Duke of York in their behalf,
 and that with a nobility of spirit,
 which exhibits an admirable specimen of the integrity of his character.
 
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
 Robert Barclay To The Princess Elizabeth.
 
-"`Theobald's, near London,
+[.signed-section-context-open]
+"`Theobald's, near London, 12th of the 7th month, 1677.
 
-12th of the 7th month, 1677.
-
+[.salutation]
 "`Dear Friend,
 
 "`By thy letter of the last of the month past,
@@ -59,7 +63,7 @@ like that of a physician frequenting his patients for
 the increase or confirmation of their health;
 but must profess, that my converse with them is,
 to receive health and refreshment from them.`"--See Appendix
-to Barclay's Second Edition of I. Penington's Letters,
+to Barclay's Second Edition of [.book-title]#I. Penington's Letters,#
 p. 311.]
 
 "`What thou writest of the counsellor of the elector, and the other preachers,
@@ -94,10 +98,13 @@ If thou seest meet to salute that counsellor of the elector in my name, thou may
 
 "`I shall add no more at present, but that I am thy real and unfeigned friend,
 
+[.signed-section-signature]
 "`Robert Barclay.`"
 
+--
+
 "`The memoirs of the family,`" says John Barclay,^
-footnote:[See "`Jaffray and the Friends in Scotland,`" by J. Barclay, p. 415.]
+footnote:[See [.book-title]#Jaffray and the Friends in Scotland,# by J. Barclay, p. 415.]
 "`state in general terms,
 that the release of both the father and son +++[+++David and Robert Barclay]
 took place by an order from court, with a reprimand for meddling with either of them;
@@ -262,7 +269,7 @@ that she observed my grandfather that morning, before they were attacked,
 more pensive than usual; and that he told her it was his opinion,
 some unusual trial or exercise was to befal them that day; but when the affair happened,
 he enjoyed a remarkable serenity.`"^
-footnote:[Barclay's Friends in Scotland, p. 443.]
+footnote:[Barclay's [.book-title]#Friends in Scotland#, p. 443.]
 
 It was in the year 1690,
 that it pleased the Divine will to summons Robert Barclay from this world.
@@ -293,11 +300,17 @@ and others of the neighbourhood.
 The following letter from the pen of George Fox, addressed on this mournful occasion,
 to the widow, is too characteristic to be omitted.
 
+[.embedded-content-document.letter]
+--
+
+[.letter-heading]
 George Fox to Christian Barclay
 
+[.signed-section-context-open]
 "`28th of 10th month, 1690.^
 footnote:[George himself lived, not much above two weeks after the date of this epistle.]
 
+[.salutation]
 "`DEAR FRIEND!
 
 "`With my love to thee and thy children, and all the rest of friends, in the holy seed,
@@ -348,7 +361,10 @@ And so, the Lord God Almighty, settle and establish thee and thine,
 upon the heavenly rock and foundation; that, as thy children grow in years,
 they may grow in grace, and so in favour with the Lord.--Amen
 
+[.signed-section-signature]
 "`George Fox.`"
+
+--
 
 The character of Robert Barclay is best given in the words of a contemporary and friend;
 both of whom were combined in William Penn, who thus describes him:--
@@ -432,6 +448,10 @@ The conclusion of this address,
 more especially commends the noble sincerity of the writer's heart; whilst,
 to the credit of the king, it must be remembered,
 that he took no offence at the Christian freedom it displays:
+
+[.embedded-content-document.letter]
+--
+
 "`God hath done great things for thee,`" says Barclay.
 "`He hath sufficiently shown thee, that it is by him princes rule,
 and that he can pull down, and set up, at his pleasure.
@@ -469,7 +489,15 @@ that are followers thereof, have also done.
 so touch and reach thy heart, ere the day of thy visitation be expired,
 that thou mayest effectually turn to him, so as to improve thy place and station,
 for his name.
-So wisheth, so prayeth, "`Thy faithful friend and subject, "`Robert Barclay.`"
+So wisheth, so prayeth,
+
+[.signed-section-closing]
+"`Thy faithful friend and subject,
+
+[.signed-section-signature]
+"`Robert Barclay.`"
+
+--
 
 This work was first published in Latin,
 when the author had only attained his twenty-eighth year,
@@ -492,4 +520,3 @@ But, a brief sketch of some of the leading subjects which it embraces,
 and with great force, and calmness of spirit, enlarges upon, may not be unacceptable;
 and which I, the rather feel inclined to offer to the reader's notice,
 in the hope of its inducing him to turn to, and consider the work itself.
-

--- a/lives-of-primitive-quakers/original/20-chapter-19.adoc
+++ b/lives-of-primitive-quakers/original/20-chapter-19.adoc
@@ -1,6 +1,6 @@
 == Chapter XIX
 
-THE "`Apology for the True Christian Divinity,`" is an
+The [.book-title]#Apology for the True Christian Divinity#, is an
 enlarged discussion of fifteen propositions,
 which the author, in his address to the reader,
 describes as briefly comprehending the chief principles and doctrines of truth.
@@ -61,7 +61,7 @@ therefore it is not the primary or adequate rule of faith.
 
 "`Next, the very nature of the gospel itself declares,
 that the Scriptures cannot be the only and chief rule of Christians;
-else there should be no difference betwixt the law and the gospel,which differ in this:
+else there should be no difference betwixt the law and the gospel, which differ in this:
 in that the law being outwardly written, brings under condemnation,
 but hath not life in it to save: whereas,
 the gospel as it declares and makes manifest the evil, so it, being an inward,
@@ -74,8 +74,7 @@ Hence, the apostle concludes, (Rom. 6:14) "`sin shall not have dominion over you
 for ye are not under the law, but under grace`'--this grace then,
 which is an inward and not an outward law, is to be the rule of Christians.
 Hence,
-the apostle commends the elders of the church to it--(Acts 20{^
-}32)--to that spiritual law which makes free from sin,
+the apostle commends the elders of the church to it--(Acts 20:32)--to that spiritual law which makes free from sin,
 (Rom. 8:2) which was not outward--as Rom. 10:8--manifests; where,
 distinguishing it from the law, he saith, "`it is nigh thee; in thy heart,
 and in thy mouth;' and this is the word of truth which we preach.`"
@@ -244,11 +243,11 @@ Secondly.
 a measure of the light of his own Son;–a measure of grace;--or, a measure of the Spirit;
 which the scripture expresses by several names,
 as sometimes of '`The seed of the kingdom,`' (Matt. 13:18-
-19) "`The light that makes all things manifest,`' (Eph. 5:
-13) '`The word of God,`" (Rom. 10:17) or,
-'`Manifestation of the Spirit given to profit withal,' (1 Cor. 12:
-7) "`A talent,`' (Matt. 25:15) "`A little leaven,`" (Matt.
-xiii.33;) '`The gospel preached in every creature,`" (Col. 1:23)
+19) '`The light that makes all things manifest,`' (Eph. 5:
+13) '`The word of God,`' (Rom. 10:17) or,
+'`Manifestation of the Spirit given to profit withal,`' (1 Cor. 12:
+7) '`A talent,`' (Matt. 25:15) '`A little leaven,`' (Matt.
+xiii.33;) '`The gospel preached in every creature,`' (Col. 1:23)
 
 Thirdly.
 "`That God in, and by this light and seed, invites, calls, exhorts,
@@ -555,8 +554,8 @@ that this "`true light enlightens EVERY man that cometh into the world.`"
 
 For what end this light is given, is expressed verse 7;
 where John is said to come for a witness to the light,
-"`that all men through it might believe; to wit, through the light, di auton,
-which,`" he says, "`doth very well agree with phogos, as being the nearest antecedent,
+"`that all men through it might believe; to wit, through the light, __di auton__,
+which,`" he says, "`doth very well agree with __phogos__, as being the nearest antecedent,
 though most translators (to make it suit with
 their own doctrine) have made it relate to John,
 as if all men were to believe through John`"--which was not possible,
@@ -707,10 +706,9 @@ as such; whom I take to be so great a man, that I profess freely,
 I had rather engage against an hundred Bellarmines, Hardings, and Stapletons,
 than with one Barclay`"--(Of Divine Light.--Tract II. p. 32.)^
 footnote:[Sir James Mackintosh also observes,
-with respect to Barclay and his "`Apology:`" "`Of those first who systematized,
+with respect to Barclay and his [.book-title]#Apology#: "`Of those first who systematized,
 and perhaps insensibly softened the Quakers' creed, was Barclay, a gentleman of Scotland,
 in his Apology for the Quakers; a masterpiece of ingenious reasoning,
 and a model of argumentative composition, which extorted praise from Bayle,
-one of the most acute and least fanatical of men.`"-- Mackintosh's Revolution in England,
+one of the most acute and least fanatical of men.`"-- Mackintosh's [.book-title]#Revolution in England#,
 p. 169.]
-

--- a/lives-of-primitive-quakers/original/21-chapter-20.adoc
+++ b/lives-of-primitive-quakers/original/21-chapter-20.adoc
@@ -1,6 +1,6 @@
 == Chapter XX
 
-AFTER his marriage, George Fox continued in the same line of ministerial service,
+After his marriage, George Fox continued in the same line of ministerial service,
 which seldom allowed him to continue long in one place.
 But the winter following this event, he was confined by illness at Enfield,
 during which time he describes his spiritual sufferings
@@ -158,6 +158,10 @@ and which he thus curiously expresses in a letter to his wife:
 he having sent her with one of her daughters home into the north as
 soon as he was taken prisoner and committed to Worcester gaol.
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear Heart,`"
 
 "`Thou seemedst to be a little grieved when I was speaking of prisons,
@@ -167,7 +171,10 @@ I had a sight of my being taken prisoner; and when I was at B. Doiley's in Oxfor
 as I sat at supper, I saw I was taken: and I saw I had a suffering to undergo.
 But the Lord's power is over all, blessed be his holy name for ever!
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 His companion in this imprisonment was Thomas Lower,
 who had married one of Margaret Fell's daughters, whose brother, Dr. Lower,
@@ -254,6 +261,10 @@ Although he was not amongst the friends who
 visited Princess Elizabeth upon this occasion,
 he addressed a long epistle to her, which he thus commences:
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Princess Elizabeth,
 
 "`I have heard of thy tenderness towards the Lord and his holy truth,
@@ -282,10 +293,17 @@ and will be a teacher unto thee at all times.`"
 He added, in a postscript, "`The bearer hereof, is a daughter-in-law of mine,
 that comes with Gertrude Dirick Nieson, and George Keith's wife, to give thee a visit.
 
+[.signed-section-signature]
 "`G. F.`"
+
+--
 
 To this plain and unceremonious epistle, the princess returned the following reply:--
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`Dear Friend,
 
 "`I cannot but have a tender love to those that love the Lord Jesus Christ,
@@ -294,12 +312,16 @@ Therefore your letter, and your friends' visit, have been both very welcome to m
 I shall follow their, and your counsel, as far as God will afford me light and unction,
 remaining still
 
+[.signed-section-closing]
 "`Your loving friend,
 
+[.signed-section-signature]
 "`Elizabeth.`"
 
-"`Hertford, 30th Aug.
-1677.`"
+[.signed-section-context-close]
+"`Hertford, 30th Aug. 1677.`"
+
+--
 
 On his return home,
 the labours of George Fox were more directed towards
@@ -351,4 +373,3 @@ and that he said to one of the noblemen who stood by,
 "`What shall we do for these people; the prisons are filled with them?`"
 But the person to whom he addressed himself, in order to draw him from the subject,
 and to divert him from his concern therein, led him into other discourse.
-

--- a/lives-of-primitive-quakers/original/22-chapter-21.adoc
+++ b/lives-of-primitive-quakers/original/22-chapter-21.adoc
@@ -58,6 +58,10 @@ and the other was of old people's going into the earth`" under
 the pressure of which exercise he wrote an epistle,
 which he addressed:
 
+[.embedded-content-document.letter]
+--
+
+[.salutation]
 "`To all that profess the truth of God.
 
 "`My desires,`" he says, "`are, that you walk humbly in it:
@@ -74,6 +78,8 @@ and 'loading yourselves with thick clay.'
 and that which leadeth into a vain mind, and the fashions of the world,
 and into the earth;--though you have often had the rain fall upon your fields,
 you will but bring forth thistles, briars, and thorns, which are for the fire,`" etc.
+
+--
 
 His last work of this kind was an epistle of
 consolation and counsel to friends in Ireland,
@@ -102,7 +108,7 @@ with a manifest decline of strength, he retired at once to his bed,
 where he lay in much contentment and peace, and very sensible to the last.
 
 "`As he lived,`" says William Penn,^
-footnote:[In his preface to G. Fox's Journal, pp.
+footnote:[In his preface to [.book-title]#G. Fox's Journal#, pp.
 30 and 31.]
 "`so he died; feeling the same eternal power that had raised and preserved him,
 in his last moments.`"
@@ -379,9 +385,7 @@ and desired that they would let us have discourse with their priests, preachers,
 and teachers, and if they could prove us erroneous, then let them manifest it;
 but if our principles and doctrines be found according to the doctrine of Christ,
 and the apostles and saints in the primitive times, then let us have our liberty.^
-footnote:[From an old work, entitled "`A brief Collection of remarkable Passages,
-etc. relating to Margaret Fell,`" (p. 4,) and
-from which the present account of her is taken.]
+footnote:[From an old work, entitled [.book-title]#A brief Collection of remarkable Passages, etc. relating to Margaret Fell#, (p. 4,) and from which the present account of her is taken.]
 
 "`But,`" as the reader will not be surprized to hear,
 "`we could never get a meeting with any sort of them.`"
@@ -520,4 +524,3 @@ painful world-- it is all nothing to me,--for my Maker is my husband.`"
 
 A little before her departure, she called her daughter Rachel to her, saying,
 "`Take me in thy arms`"--after which, she said, "`I am in peace!`"
-

--- a/lives-of-primitive-quakers/original/23-chapter-22.adoc
+++ b/lives-of-primitive-quakers/original/23-chapter-22.adoc
@@ -29,7 +29,7 @@ whence you are derived;--illustrious in that true nobility which comes from God.
 
 "`What is it,`" says one of those truly illustrious ones,^
 footnote:[Isaac Penington.--See his Epistle to Friends, vol.
-ii p. 645, of his Works, in two vols.]--"`What is it to have a distinct name,
+ii p. 645, of his [.book-title]#Works#, in two vols.]--"`What is it to have a distinct name,
 or distinct meetings from the world, unless the power of the Lord be felt in your hearts,
 and his presence in your assemblies?`"
 What is it indeed, but setting up a broader mark than common,
@@ -97,7 +97,7 @@ Nay, the Lord knows,
 that the love of these things is daily rooted out of our hearts more and more,
 and we are a people whom the world cannot charge with covetousness or love of the world,
 wherewith all sorts of professors hitherto have been too justly chargeable.`"^
-footnote:[Isaac Penington, vol i. p. 302 of his Works.]
+footnote:[Isaac Penington, vol i. p. 302 of his [.book-title]#Works#.]
 
 Oh, friends! if in the least measure,
 a mightier hand than that frail one which traces these lines,
@@ -330,7 +330,7 @@ how beautiful to the enlightened eye is your memorial!
 Ye were God's building; and of that edifice which the Almighty rears,
 how truly doth one amongst you thus express the character.^
 footnote:[Isaac Penington.
-See his Letters, published by J. Barclay, p. 84.]
+See his [.book-title]#Letters#, published by J. Barclay, p. 84.]
 
 "`Into thy holy building, O God! into thy heavenly building,
 into the spiritual Jerusalem, which thou rearest and buildest up in the Spirit,
@@ -367,4 +367,5 @@ and that only which you have received, and that not of man,
 nor by any of the natural workings of your own minds;
 "`but by the revelation of Jesus Christ!`"
 
+[.the-end]
 Finis


### PR DESCRIPTION
FYI some of the footnotes in Kelty had book titles (which I marked), but wherever there was a long dash (or double dash in asciidoc) before the author's name IN a footnote, it messed up the rendering.  Like, if Kelty said The Apology --R. Barclay, I had to remove the double dash and change it to "by R. Barclay" for it to render correctly. 